### PR TITLE
Updated Slovak national-wide testing data

### DIFF
--- a/Slovakia_National_Testing_Municipality_Data.csv
+++ b/Slovakia_National_Testing_Municipality_Data.csv
@@ -1,2695 +1,2698 @@
-﻿RHQ,State,County,Municipality,E2_tested,E2_positive,E2_percentage,E3_tested,E3_positive,E3_percentage
-Prešov,Prešovský,Stará Ľubovňa,Obručné,27,4,14.81%,,,
-Prešov,Prešovský,Stará Ľubovňa,Čirč,713,81,11.36%,535,32,5.98%
-Michalovce,Košický,Michalovce,Markovce,544,48,8.82%,447,27,6.04%
-Ružomberok,Žilinský,Liptovský Mikuláš,Liptovská Sielnica,279,21,7.53%,268,0,0.00%
-Prešov,Prešovský,Kežmarok,Spišské Hanušovce,457,32,7.00%,378,9,2.38%
-Trenčín,Trenčiansky,Púchov,Záriečie,615,42,6.83%,485,11,2.27%
-Prešov,Prešovský,Stará Ľubovňa,Ruská Voľa nad Popradom,104,7,6.73%,108,0,0.00%
-Prešov,Prešovský,Poprad,Vydrník,820,55,6.71%,686,14,2.04%
-Prešov,Prešovský,Bardejov,Nemcovce,120,8,6.67%,113,0,0.00%
-Prešov,Prešovský,Kežmarok,Matiašovce,432,28,6.48%,409,3,0.73%
-Prešov,Prešovský,Poprad,Spišský Štiavnik,1741,111,6.38%,1460,30,2.05%
-Prešov,Prešovský,Svidník,Matovce,49,3,6.12%,57,0,0.00%
-Prešov,Prešovský,Bardejov,Malcov,753,46,6.11%,821,26,3.17%
-Trenčín,Trenčiansky,Považská Bystrica,Malé Lednice,385,23,5.97%,328,2,0.61%
-Trenčín,Trenčiansky,Púchov,Horovce,603,36,5.97%,546,6,1.10%
-Topoľčany,Trenčiansky,Partizánske,Livinské Opatovce,137,8,5.84%,184,1,0.54%
-Michalovce,Prešovský,Humenné,Karná,319,18,5.64%,298,0,0.00%
-Prešov,Prešovský,Bardejov,Ortuťová,110,6,5.45%,111,5,4.50%
-Prešov,Prešovský,Poprad,Jánovce,1124,61,5.43%,977,10,1.02%
-Prešov,Prešovský,Svidník,Kapišová,74,4,5.41%,224,0,0.00%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Pochabany,241,13,5.39%,227,1,0.44%
-Prešov,Prešovský,Levoča,Vyšný Slavkov,204,11,5.39%,197,0,0.00%
-Prešov,Prešovský,Stará Ľubovňa,Matysová,75,4,5.33%,110,1,0.91%
-Prešov,Prešovský,Stará Ľubovňa,Stráňany,94,5,5.32%,114,0,0.00%
-Prešov,Prešovský,Stará Ľubovňa,Kyjov,794,42,5.29%,468,4,0.85%
-Prešov,Prešovský,Svidník,Vyšný Orlík,267,14,5.24%,230,1,0.43%
-Prešov,Prešovský,Stará Ľubovňa,Kolačkov,732,38,5.19%,645,14,2.17%
-Michalovce,Košický,Michalovce,Hatalov,848,44,5.19%,437,4,0.92%
-Trenčín,Trenčiansky,Púchov,Dolné Kočkovce,642,33,5.14%,752,20,2.66%
-Michalovce,Prešovský,Medzilaborce,Radvaň nad Laborcom,527,27,5.12%,401,0,0.00%
-Prešov,Prešovský,Prešov,Geraltov,99,5,5.05%,185,2,1.08%
-Prešov,Prešovský,Bardejov,Kožany,120,6,5.00%,101,0,0.00%
-Zvolen,Banskobystrický,Žarnovica,Kľak,100,5,5.00%,,,
-Ružomberok,Žilinský,Liptovský Mikuláš,Svätý Kríž,807,40,4.96%,679,2,0.29%
-Prešov,Prešovský,Stará Ľubovňa,Hromoš,406,20,4.93%,314,5,1.59%
-Prešov,Prešovský,Stará Ľubovňa,Pusté Pole,122,6,4.92%,107,2,1.87%
-Prešov,Prešovský,Stropkov,Malá Poľana,61,3,4.92%,58,0,0.00%
-Žilina,Žilinský,Čadca,Turzovka,3889,190,4.89%,3738,37,0.99%
-Prešov,Prešovský,Sabinov,Ďačov,496,24,4.84%,476,7,1.47%
-Prešov,Prešovský,Kežmarok,Veľká Franková,270,13,4.81%,283,4,1.41%
-Trenčín,Trenčiansky,Púchov,Lednica,569,27,4.75%,532,10,1.88%
-Prešov,Prešovský,Stará Ľubovňa,Lesnica,339,16,4.72%,261,2,0.77%
-Prešov,Prešovský,Bardejov,Buclovany,106,5,4.72%,97,0,0.00%
-Prešov,Prešovský,Stropkov,Baňa,85,4,4.71%,103,0,0.00%
-Ružomberok,Žilinský,Tvrdošín,Liesek,1595,75,4.70%,1567,16,1.02%
-Prešov,Prešovský,Stropkov,Kručov,171,8,4.68%,173,0,0.00%
-Žilina,Žilinský,Čadca,Korňa,1283,60,4.68%,1119,7,0.63%
-Topoľčany,Trenčiansky,Prievidza,Čereňany,1043,48,4.60%,1011,12,1.19%
-Trenčín,Trenčiansky,Púchov,Mestečko,243,11,4.53%,245,6,2.45%
-Žilina,Žilinský,Čadca,Klokočov,1532,69,4.50%,1418,15,1.06%
-Ružomberok,Žilinský,Liptovský Mikuláš,Prosiek,357,16,4.48%,290,2,0.69%
-Žilina,Žilinský,Čadca,Stará Bystrica,1767,78,4.41%,1666,11,0.66%
-Ružomberok,Žilinský,Liptovský Mikuláš,Kvačany,228,10,4.39%,250,1,0.40%
-Prešov,Prešovský,Sabinov,Krásna Lúka,480,21,4.38%,424,2,0.47%
-Prešov,Prešovský,Svidník,Dukovce,138,6,4.35%,139,0,0.00%
-Prešov,Prešovský,Levoča,Spišský Hrhov,812,35,4.31%,817,10,1.22%
-Martin,Žilinský,Turčianske Teplice,Liešno,93,4,4.30%,58,0,0.00%
-Prešov,Prešovský,Levoča,Korytné,142,6,4.23%,142,1,0.70%
-Prešov,Prešovský,Stará Ľubovňa,Forbasy,474,20,4.22%,340,6,1.76%
-Rožňava,Košický,Spišská Nová Ves,Letanovce,1178,49,4.16%,1356,15,1.11%
-Topoľčany,Nitriansky,Topoľčany,Tvrdomestice,242,10,4.13%,260,3,1.15%
-Prešov,Prešovský,Levoča,Dravce,558,23,4.12%,504,7,1.39%
-Žilina,Žilinský,Čadca,Dlhá nad Kysucou,707,29,4.10%,622,4,0.64%
-Prešov,Prešovský,Bardejov,Vyšná Polianka,122,5,4.10%,108,0,0.00%
-Sereď,Trnavský,Dunajská Streda,Vrakúň,1491,61,4.09%,1555,31,1.99%
-Trenčín,Trenčiansky,Trenčín,Horná Súča,2108,86,4.08%,1933,11,0.57%
-Prešov,Prešovský,Sabinov,Poloma,491,20,4.07%,485,1,0.21%
-Prešov,Prešovský,Stará Ľubovňa,Veľká Lesná,345,14,4.06%,296,1,0.34%
-Prešov,Prešovský,Bardejov,Hrabské,249,10,4.02%,306,10,3.27%
-Prešov,Prešovský,Bardejov,Bartošovce,503,20,3.98%,478,1,0.21%
-Prešov,Prešovský,Sabinov,Šarišské Dravce,629,25,3.97%,611,2,0.33%
-Topoľčany,Nitriansky,Topoľčany,Horné Obdokovce,682,27,3.96%,818,2,0.24%
-Prešov,Prešovský,Svidník,Mičakovce,228,9,3.95%,200,0,0.00%
-Trenčín,Trenčiansky,Púchov,Dolná Breznica,507,20,3.94%,527,20,3.80%
-Trebišov,Košický,Trebišov,Zemplínska Teplica,970,38,3.92%,,,
-Prešov,Prešovský,Stará Ľubovňa,Jarabina,441,17,3.85%,412,2,0.49%
-Michalovce,Košický,Michalovce,Sliepkovce,496,19,3.83%,475,1,0.21%
-Prešov,Prešovský,Bardejov,Smilno,470,18,3.83%,443,9,2.03%
-Topoľčany,Trenčiansky,Partizánske,Veľké Krštenany,470,18,3.83%,348,4,1.15%
-Prešov,Prešovský,Stará Ľubovňa,Kamienka,683,26,3.81%,667,19,2.85%
-Žilina,Žilinský,Čadca,Raková,3384,128,3.78%,3180,26,0.82%
-Michalovce,Prešovský,Humenné,Baškovce,503,19,3.78%,436,6,1.38%
-Topoľčany,Trenčiansky,Prievidza,Poruba,980,37,3.78%,829,9,1.09%
-Michalovce,Prešovský,Humenné,Myslina,424,16,3.77%,369,4,1.08%
-Michalovce,Košický,Sobrance,Nižná Rybnica,265,10,3.77%,256,2,0.78%
-Prešov,Prešovský,Kežmarok,Majere,53,2,3.77%,57,0,0.00%
-Topoľčany,Trenčiansky,Prievidza,Šútovce,239,9,3.77%,226,1,0.44%
-Prešov,Prešovský,Kežmarok,Jezersko,186,7,3.76%,150,2,1.33%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Miezgovce,160,6,3.75%,142,0,0.00%
-Trenčín,Trenčiansky,Púchov,Lysá pod Makytou,1097,41,3.74%,1089,20,1.84%
-Prešov,Prešovský,Sabinov,Šarišské Sokolovce,429,16,3.73%,394,5,1.27%
-Ružomberok,Žilinský,Tvrdošín,Štefanov nad Oravou,492,18,3.66%,449,7,1.56%
-Prešov,Prešovský,Stará Ľubovňa,Haligovce,411,15,3.65%,416,8,1.92%
-Prešov,Prešovský,Bardejov,Hrabovec,331,12,3.63%,306,6,1.96%
-Prešov,Prešovský,Bardejov,Janovce,222,8,3.60%,289,5,1.73%
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Brunovce,530,19,3.58%,786,9,1.15%
-Zvolen,Banskobystrický,Brezno,Osrblie,363,13,3.58%,347,1,0.29%
-Ružomberok,Žilinský,Ružomberok,Stankovany,702,25,3.56%,690,4,0.58%
-Žilina,Žilinský,Žilina,Podhorie,735,26,3.54%,625,4,0.64%
-Topoľčany,Trenčiansky,Prievidza,Tužina,921,32,3.47%,846,1,0.12%
-Prešov,Prešovský,Stropkov,Oľšavka,116,4,3.45%,159,0,0.00%
-Michalovce,Košický,Michalovce,Závadka,407,14,3.44%,389,0,0.00%
-Ružomberok,Žilinský,Tvrdošín,Čimhová,529,18,3.40%,466,2,0.43%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Kšinná,471,16,3.40%,468,6,1.28%
-Prešov,Prešovský,Svidník,Šarišský Štiavnik,118,4,3.39%,112,1,0.89%
-Žilina,Žilinský,Čadca,Skalité,3134,106,3.38%,2945,33,1.12%
-Trenčín,Trenčiansky,Púchov,Zubák,652,22,3.37%,608,17,2.80%
-Prešov,Prešovský,Sabinov,Kamenica,979,33,3.37%,986,11,1.12%
-Rožňava,Košický,Spišská Nová Ves,Vítkovce,386,13,3.37%,316,14,4.43%
-Prešov,Prešovský,Sabinov,Sabinov,5770,194,3.36%,6138,75,1.22%
-Prešov,Prešovský,Stará Ľubovňa,Sulín,149,5,3.36%,160,0,0.00%
-Ružomberok,Žilinský,Tvrdošín,Zábiedovo,568,19,3.35%,526,10,1.90%
-Trenčín,Trenčiansky,Považská Bystrica,Klieština,150,5,3.33%,169,2,1.18%
-Prešov,Prešovský,Poprad,Hozelec,600,20,3.33%,531,3,0.56%
-Prešov,Prešovský,Kežmarok,Červený Kláštor,90,3,3.33%,122,0,0.00%
-Topoľčany,Trenčiansky,Prievidza,Lipník,542,18,3.32%,422,7,1.66%
-Michalovce,Košický,Michalovce,Slavkovce,604,20,3.31%,536,5,0.93%
-Michalovce,Košický,Sobrance,Hlivištia,393,13,3.31%,399,10,2.51%
-Žilina,Žilinský,Čadca,Nová Bystrica,2117,70,3.31%,1594,27,1.69%
-Michalovce,Prešovský,Humenné,Hrabovec nad Laborcom,333,11,3.30%,321,2,0.62%
-Prešov,Prešovský,Levoča,Kurimany,212,7,3.30%,197,4,2.03%
-Trenčín,Trenčiansky,Púchov,Kvašov,547,18,3.29%,485,10,2.06%
-Prešov,Prešovský,Stropkov,Chotča,456,15,3.29%,417,1,0.24%
-Prešov,Prešovský,Stará Ľubovňa,Nižné Ružbachy,488,16,3.28%,443,5,1.13%
-Prešov,Prešovský,Kežmarok,Hradisko,399,13,3.26%,215,0,0.00%
-Prešov,Prešovský,Stará Ľubovňa,Šarišské Jastrabie,677,22,3.25%,718,3,0.42%
-Žilina,Žilinský,Čadca,Zborov nad Bystricou,1480,48,3.24%,1315,14,1.06%
-Prešov,Prešovský,Sabinov,Oľšov,216,7,3.24%,210,0,0.00%
-Martin,Žilinský,Martin,Blatnica,620,20,3.23%,626,6,0.96%
-Prešov,Prešovský,Stropkov,Jakušovce,31,1,3.23%,28,0,0.00%
-Trenčín,Trenčiansky,Púchov,Lazy pod Makytou,1086,35,3.22%,1081,16,1.48%
-Topoľčany,Trenčiansky,Prievidza,Diviacká nová Ves,963,31,3.22%,926,10,1.08%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Dvorec,187,6,3.21%,199,0,0.00%
-Prešov,Prešovský,Levoča,Spišský Štvrtok,1621,52,3.21%,1519,14,0.92%
-Prešov,Prešovský,Bardejov,Kochanovce,156,5,3.21%,132,1,0.76%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Čierna Lehota,219,7,3.20%,228,8,3.51%
-Michalovce,Prešovský,Humenné,Vyšný Hrušov,313,10,3.19%,305,0,0.00%
-Prešov,Prešovský,Poprad,Vikartovce,1222,39,3.19%,1091,8,0.73%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Malé Hoste,157,5,3.18%,147,0,0.00%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Podlužany,724,23,3.18%,656,2,0.30%
-Prešov,Prešovský,Sabinov,Bajerovce,189,6,3.17%,198,3,1.52%
-Prešov,Prešovský,Bardejov,Jedlinka,126,4,3.17%,100,0,0.00%
-Prešov,Prešovský,Levoča,Poľanovce,158,5,3.16%,152,2,1.32%
-Prešov,Prešovský,Poprad,Ždiar,727,23,3.16%,789,1,0.13%
-Michalovce,Košický,Michalovce,Vrbnica,508,16,3.15%,380,6,1.58%
-Žilina,Žilinský,Čadca,Klubina,572,18,3.15%,511,5,0.98%
-Prešov,Prešovský,Svidník,Želmanovce,159,5,3.14%,168,0,0.00%
-Rožňava,Košický,Spišská Nová Ves,Lieskovany,350,11,3.14%,273,1,0.37%
-Žilina,Žilinský,Čadca,Vysoká nad Kysucou,1623,51,3.14%,1561,12,0.77%
-Michalovce,Prešovský,Humenné,Brestov,382,12,3.14%,369,3,0.81%
-Martin,Žilinský,Turčianske Teplice,Moškovec,223,7,3.14%,175,2,1.14%
-Michalovce,Prešovský,Humenné,Hrubov,287,9,3.14%,247,2,0.81%
-Prešov,Prešovský,Prešov,Trnkov,128,4,3.13%,133,0,0.00%
-Rožňava,Košický,Spišská Nová Ves,Hrabušice,1548,48,3.10%,1474,26,1.76%
-Topoľčany,Trenčiansky,Prievidza,Kocurany,646,20,3.10%,488,2,0.41%
-Prešov,Prešovský,Kežmarok,Reľov,291,9,3.09%,264,4,1.52%
-Prešov,Prešovský,Stará Ľubovňa,Nová Ľubovňa,1717,53,3.09%,1639,26,1.59%
-Zvolen,Banskobystrický,Veľký Krtíš,Kosihy nad Ipľom,162,5,3.09%,,,
-Prešov,Prešovský,Sabinov,Torysa,940,29,3.09%,1420,7,0.49%
-Martin,Žilinský,Dolný Kubín,Malatiná,487,15,3.08%,508,2,0.39%
-Prešov,Prešovský,Svidník,Cernina,325,10,3.08%,333,0,0.00%
-Rožňava,Košický,Rožňava,Slavoška,65,2,3.08%,,,
-Michalovce,Prešovský,Humenné,Hankovce,423,13,3.07%,383,4,1.04%
-Michalovce,Prešovský,Vranov nad Topľou,Zámutov,1864,57,3.06%,1714,39,2.28%
-Rožňava,Košický,Spišská Nová Ves,Hincovce,131,4,3.05%,147,1,0.68%
-Michalovce,Prešovský,Humenné,Lukačovce,493,15,3.04%,475,5,1.05%
-Prešov,Prešovský,Stará Ľubovňa,Plavnica,888,27,3.04%,913,10,1.10%
-Žilina,Žilinský,Žilina,Belá,2351,71,3.02%,2273,13,0.57%
-Trenčín,Trenčiansky,Považská Bystrica,Horný Lieskov,199,6,3.02%,210,0,0.00%
-Žilina,Žilinský,Čadca,Čierne,2523,76,3.01%,2488,21,0.84%
-Michalovce,Prešovský,Humenné,Zubné,399,12,3.01%,374,2,0.53%
-Prešov,Prešovský,Sabinov,Lúčka,566,17,3.00%,510,4,0.78%
-Prešov,Prešovský,Kežmarok,Malá Franková,333,10,3.00%,116,2,1.72%
-Topoľčany,Trenčiansky,Prievidza,Opatovce nad Nitrou,834,25,3.00%,741,6,0.81%
-Michalovce,Prešovský,Medzilaborce,Kalinov,334,10,2.99%,210,1,0.48%
-Prešov,Prešovský,Svidník,Kečkovce,167,5,2.99%,159,0,0.00%
-Topoľčany,Trenčiansky,Prievidza,Kostolná Ves,602,18,2.99%,471,3,0.64%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Malá Hradná,236,7,2.97%,217,1,0.46%
-Trenčín,Trenčiansky,Považská Bystrica,DOMANIŽA,1283,38,2.96%,1131,7,0.62%
-Topoľčany,Trenčiansky,Prievidza,Bystričnany,1184,35,2.96%,1173,5,0.43%
-Martin,Žilinský,Dolný Kubín,Kraľovany,474,14,2.95%,440,0,0.00%
-Prešov,Prešovský,Svidník,Kalnište,271,8,2.95%,275,4,1.45%
-Prešov,Prešovský,Bardejov,Rokytov,713,21,2.95%,267,11,4.12%
-Rožňava,Košický,Gelnica,Závadka,442,13,2.94%,370,5,1.35%
-Michalovce,Prešovský,Vranov nad Topľou,Majerovce,477,14,2.94%,422,1,0.24%
-Topoľčany,Trenčiansky,Prievidza,Veľká Lehôtka,682,20,2.93%,668,4,0.60%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Brezolupy,239,7,2.93%,231,3,1.30%
-Trenčín,Trenčiansky,Trenčín,Veľká Hradná,548,16,2.92%,483,3,0.62%
-Ružomberok,Žilinský,Tvrdošín,Vitanová,755,22,2.91%,779,9,1.16%
-Prešov,Prešovský,Svidník,Nižný Komárnik,103,3,2.91%,93,0,0.00%
-Martin,Žilinský,Martin,Turčianska Štiavnička,688,20,2.91%,643,10,1.56%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Uhrovské Podhradie,413,12,2.91%,411,1,0.24%
-Trenčín,Trenčiansky,Púchov,Horná Breznica,207,6,2.90%,193,3,1.55%
-Prešov,Prešovský,Bardejov,Zlaté,449,13,2.90%,529,6,1.13%
-Martin,Žilinský,Námestovo,Babín,864,25,2.89%,830,3,0.36%
-Martin,Žilinský,Martin,Karlová,346,10,2.89%,175,0,0.00%
-Žilina,Žilinský,Kysucké Nové Mesto,Dolný Vadičov,312,9,2.88%,451,0,0.00%
-Prešov,Prešovský,Kežmarok,Lendak,3095,89,2.88%,2994,48,1.60%
-Topoľčany,Nitriansky,Topoľčany,Bojná,1326,38,2.87%,1300,6,0.46%
-Zvolen,Banskobystrický,Banská Bystrica,Strelníky,594,17,2.86%,571,0,0.00%
-Žilina,Žilinský,Čadca,Zákopčie,1260,36,2.86%,1201,6,0.50%
-Žilina,Žilinský,Žilina,Nezbudská Lúčka,281,8,2.85%,265,2,0.75%
-Hlohovec,Trnavský,Hlohovec,Merašice,528,15,2.84%,,,
-Trenčín,Trenčiansky,Púchov,Lednické Rovne,3030,86,2.84%,2853,64,2.24%
-Prešov,Prešovský,Stropkov,Gribov,177,5,2.82%,129,1,0.78%
-Prešov,Prešovský,Bardejov,Mikulášová,71,2,2.82%,73,0,0.00%
-Martin,Žilinský,Námestovo,Lokca,1246,35,2.81%,1330,6,0.45%
-Žilina,Žilinský,Čadca,Olešná,1034,29,2.80%,949,2,0.21%
-Michalovce,Prešovský,Humenné,Papín,536,15,2.80%,513,1,0.19%
-Topoľčany,Nitriansky,Topoľčany,Veľké Dvorany,608,17,2.80%,583,7,1.20%
-Michalovce,Prešovský,Vranov nad Topľou,Nižný Hrušov,967,27,2.79%,861,7,0.81%
-Topoľčany,Trenčiansky,Prievidza,Liešťany,681,19,2.79%,713,4,0.56%
-Prešov,Prešovský,Sabinov,Vysoká,251,7,2.79%,227,0,0.00%
-Prešov,Prešovský,Stará Ľubovňa,Vislanka,324,9,2.78%,250,2,0.80%
-Prešov,Prešovský,Prešov,Kojatice,828,23,2.78%,717,4,0.56%
-Ružomberok,Žilinský,Tvrdošín,Suchá Hora,829,23,2.77%,833,5,0.60%
-Michalovce,Prešovský,Humenné,Pakostov,325,9,2.77%,330,1,0.30%
-Prešov,Prešovský,Levoča,Bijacovce,578,16,2.77%,575,1,0.17%
-Prešov,Prešovský,Prešov,Podhorany,543,15,2.76%,714,11,1.54%
-Prešov,Prešovský,Svidník,Cigla,145,4,2.76%,113,0,0.00%
-Topoľčany,Trenčiansky,Prievidza,Lazany,1017,28,2.75%,942,11,1.17%
-Prešov,Prešovský,Bardejov,Vyšná Voľa,182,5,2.75%,211,3,1.42%
-Rožňava,Košický,Rimavská Sobota,Ratkovská Suchá,73,2,2.74%,,,
-Žilina,Žilinský,Čadca,Čadca,11703,319,2.73%,12492,136,1.09%
-Ružomberok,Žilinský,Ružomberok,Lisková,1397,38,2.72%,1418,12,0.85%
-Topoľčany,Nitriansky,Topoľčany,Závada,515,14,2.72%,485,1,0.21%
-Žilina,Žilinský,Žilina,Hričovské Podhradie,552,15,2.72%,482,2,0.41%
-Žilina,Žilinský,Žilina,Kľače,221,6,2.71%,232,1,0.43%
-Prešov,Prešovský,Stará Ľubovňa,Starina,148,4,2.70%,132,1,0.76%
-Sereď,Trnavský,Dunajská Streda,Baka,556,15,2.70%,835,11,1.32%
-Prešov,Prešovský,Bardejov,Lenartov,706,19,2.69%,679,7,1.03%
-Prešov,Prešovský,Sabinov,Nižný Slavkov,446,12,2.69%,427,5,1.17%
-Topoľčany,Trenčiansky,Prievidza,Jalovec,632,17,2.69%,509,2,0.39%
-Ružomberok,Žilinský,Liptovský Mikuláš,Žiar,299,8,2.68%,327,5,1.53%
-Topoľčany,Trenčiansky,Prievidza,Nitrianské Rudno,785,21,2.68%,859,6,0.70%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Vysočany,75,2,2.67%,82,0,0.00%
-Žilina,Žilinský,Čadca,Oščadnica,3676,98,2.67%,3638,39,1.07%
-Martin,Žilinský,Martin,Záborie,338,9,2.66%,205,3,1.46%
-Prešov,Prešovský,Stropkov,Havaj,263,7,2.66%,292,2,0.68%
-Prešov,Prešovský,Kežmarok,Krížová Ves,1467,39,2.66%,1304,15,1.15%
-Prešov,Prešovský,Bardejov,Kružlov,527,14,2.66%,551,3,0.54%
-Ružomberok,Žilinský,Ružomberok,Liptovské Sliače,2000,53,2.65%,1954,13,0.67%
-Prešov,Prešovský,Prešov,Fričovce,607,16,2.64%,655,3,0.46%
-Trenčín,Trenčiansky,Ilava,Horná Poruba,685,18,2.63%,701,5,0.71%
-Martin,Žilinský,Dolný Kubín,Chlebnice,762,20,2.62%,821,7,0.85%
-Martin,Žilinský,Dolný Kubín,Pokrývač,191,5,2.62%,159,1,0.63%
-Martin,Žilinský,Martin,Dražkovce,727,19,2.61%,647,3,0.46%
-Martin,Žilinský,Turčianske Teplice,Háj,421,11,2.61%,388,1,0.26%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Šípkov,383,10,2.61%,346,2,0.58%
-Topoľčany,Nitriansky,Topoľčany,Urmince,690,18,2.61%,779,6,0.77%
-Rožňava,Košický,Spišská Nová Ves,Arnutovce,729,19,2.61%,605,5,0.83%
-Michalovce,Prešovský,Vranov nad Topľou,Žalobín,499,13,2.61%,486,1,0.21%
-Ružomberok,Žilinský,Ružomberok,Likavka,1651,43,2.60%,1613,7,0.43%
-Topoľčany,Nitriansky,Topoľčany,Horné Štitáre,576,15,2.60%,624,3,0.48%
-Trenčín,Trenčiansky,Púchov,Beluša,3194,83,2.60%,3181,43,1.35%
-Topoľčany,Nitriansky,Topoľčany,Lipovník,194,5,2.58%,215,0,0.00%
-Ružomberok,Žilinský,Tvrdošín,Brezovica,856,22,2.57%,837,9,1.08%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Borčany,428,11,2.57%,289,0,0.00%
-Prešov,Prešovský,Svidník,Nižná Pisaná,78,2,2.56%,60,0,0.00%
-Prešov,Prešovský,Prešov,Malý Slivník,704,18,2.56%,577,21,3.64%
-Žilina,Žilinský,Žilina,Horný Hričov,626,16,2.56%,614,4,0.65%
-Topoľčany,Trenčiansky,Prievidza,Kamenec pod Vtáčnikom,1136,29,2.55%,1173,2,0.17%
-Trenčín,Trenčiansky,Púchov,Visolaje,629,16,2.54%,644,9,1.40%
-Rožňava,Košický,Poltár,Selce,118,3,2.54%,,,
-Levice,Nitrianský,Levice,Hontianské Trsťany,197,5,2.54%,,,
-Topoľčany,Trenčiansky,Partizánske,Krásno,710,18,2.54%,528,2,0.38%
-Zvolen,Banskobystrický,Žarnovica,Hodruša - Hámre (Kopanice),79,2,2.53%,,,
-Martin,Žilinský,Námestovo,Rabča,2736,69,2.52%,2825,16,0.57%
-Prešov,Prešovský,Sabinov,Drienica,635,16,2.52%,665,5,0.75%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Nedašovce,516,13,2.52%,282,7,2.48%
-Prešov,Prešovský,Prešov,Klenov,278,7,2.52%,228,1,0.44%
-Prešov,Prešovský,Prešov,Kokošovce,478,12,2.51%,658,3,0.46%
-Žilina,Žilinský,Čadca,Krásno nad Kysucou,4542,114,2.51%,4471,32,0.72%
-Trenčín,Trenčiansky,Považská Bystrica,Slopná,279,7,2.51%,261,1,0.38%
-Trenčín,Trenčiansky,Trenčín,Hrabovka,439,11,2.51%,351,0,0.00%
-Prešov,Prešovský,Stropkov,Vladiča,40,1,2.50%,44,1,2.27%
-Michalovce,Prešovský,Humenné,Ľubiša,761,19,2.50%,714,11,1.54%
-Trenčín,Trenčiansky,Púchov,Streženice,721,18,2.50%,749,7,0.93%
-Martin,Žilinský,Námestovo,Mútne,1723,43,2.50%,1733,12,0.69%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Dežerice,682,17,2.49%,682,4,0.59%
-Topoľčany,Trenčiansky,Partizánske,Žabokreky n/N,1003,25,2.49%,1075,3,0.28%
-Michalovce,Prešovský,Humenné,Brekov,723,18,2.49%,686,2,0.29%
-Topoľčany,Trenčiansky,Prievidza,Ráztočno,804,20,2.49%,756,5,0.66%
-Nitra,Nitriansky,Nitra,Žirany,926,23,2.48%,,,
-Prešov,Prešovský,Kežmarok,Žakovce,564,14,2.48%,532,7,1.32%
-Topoľčany,Nitriansky,Topoľčany,Tovarníky.,968,24,2.48%,932,7,0.75%
-Martin,Žilinský,Turčianske Teplice,Rudno,202,5,2.48%,195,1,0.51%
-Trenčín,Trenčiansky,Trenčín,Neporadza,570,14,2.46%,551,9,1.63%
-Žilina,Žilinský,Bytča,Petrovice,1064,26,2.44%,1054,9,0.85%
-Topoľčany,Trenčiansky,Prievidza,Diviaky nad Nitricou,1229,30,2.44%,1200,14,1.17%
-Prešov,Prešovský,Stará Ľubovňa,Šambron,205,5,2.44%,204,5,2.45%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Slatinka nad Bebravou,123,3,2.44%,130,2,1.54%
-Topoľčany,Trenčiansky,Partizánske,Pažiť,656,16,2.44%,404,5,1.24%
-Prešov,Prešovský,Svidník,Valkovce,164,4,2.44%,138,1,0.72%
-Prešov,Prešovský,Sabinov,Rožkovany,821,20,2.44%,789,2,0.25%
-Topoľčany,Nitriansky,Topoľčany,Krtovce,329,8,2.43%,305,6,1.97%
-Rožňava,Košický,Spišská Nová Ves,Chrasť nad Hornádom,617,15,2.43%,557,4,0.72%
-Martin,Žilinský,Martin,Šútovo,453,11,2.43%,422,1,0.24%
-Prešov,Prešovský,Stará Ľubovňa,Plaveč,825,20,2.42%,896,7,0.78%
-Levice,Nitrianský,Levice,Tupá,455,11,2.42%,,,
-Prešov,Prešovský,Stará Ľubovňa,Údol,207,5,2.42%,177,2,1.13%
-Prešov,Prešovský,Prešov,Bertotovce,166,4,2.41%,340,3,0.88%
-Topoľčany,Nitriansky,Topoľčany,Čeľadince,415,10,2.41%,387,0,0.00%
-Martin,Žilinský,Martin,Nolčovo,374,9,2.41%,275,1,0.36%
-Trenčín,Trenčiansky,Púchov,Lúky,915,22,2.40%,835,10,1.20%
-Žilina,Žilinský,Čadca,Makov,1290,31,2.40%,1255,11,0.88%
-Martin,Žilinský,Námestovo,Zakamenné,3123,75,2.40%,3256,28,0.86%
-Trenčín,Trenčiansky,Považská Bystrica,Hatné,501,12,2.40%,443,4,0.90%
-Ružomberok,Žilinský,Tvrdošín,Trstená,3718,89,2.39%,3833,32,0.83%
-Michalovce,Košický,Sobrance,Fekišovce,209,5,2.39%,185,0,0.00%
-Prešov,Prešovský,Sabinov,Krivany,669,16,2.39%,623,1,0.16%
-Ružomberok,Žilinský,Liptovský Mikuláš,Smrečany,628,15,2.39%,576,0,0.00%
-Prešov,Prešovský,Bardejov,Tarnov,419,10,2.39%,343,5,1.46%
-Ružomberok,Žilinský,Ružomberok,Švošov,545,13,2.39%,518,2,0.39%
-Nitra,Nitriansky,Nitra,Horné Leftanovce,545,13,2.39%,,,
-Martin,Žilinský,Turčianske Teplice,Rakša,337,8,2.37%,313,0,0.00%
-Topoľčany,Trenčiansky,Prievidza,Malá Čausa,548,13,2.37%,425,5,1.18%
-Trenčín,Trenčiansky,Púchov,Dohňany,1646,39,2.37%,1307,19,1.45%
-Nitra,Nitriansky,Nitra,Alekšince,1014,24,2.37%,,,
-Prešov,Prešovský,Bardejov,Kurima,634,15,2.37%,646,7,1.08%
-Prešov,Prešovský,Prešov,Bajerov,423,10,2.36%,349,0,0.00%
-Trenčín,Trenčiansky,Považská Bystrica,KOSTOLEC,339,8,2.36%,240,1,0.42%
-Žilina,Žilinský,Bytča,Maršová - Rašov,551,13,2.36%,563,4,0.71%
-Trenčín,Trenčiansky,Trenčín,Motešice,636,15,2.36%,605,2,0.33%
-Trenčín,Trenčiansky,Púchov,Púchov,10234,241,2.35%,9713,139,1.43%
-Ružomberok,Žilinský,Ružomberok,Ludrová,637,15,2.35%,614,3,0.49%
-Zvolen,Banskobystrický,Banská Bystrica,Baláže,170,4,2.35%,196,2,1.02%
-Ružomberok,Žilinský,Ružomberok,Štiavnička,638,15,2.35%,548,0,0.00%
-Topoľčany,Trenčiansky,Prievidza,Nováky,2682,63,2.35%,2634,19,0.72%
-Žilina,Žilinský,Kysucké Nové Mesto,Povina,1107,26,2.35%,868,7,0.81%
-Rožňava,Košický,Spišská Nová Ves,Žehra,1491,35,2.35%,881,6,0.68%
-Trebišov,Košický,Košice - okolie,Čakanovce,469,11,2.35%,,,
-Michalovce,Prešovský,Snina,Dlhé nad Cirochou,1025,24,2.34%,998,6,0.60%
-Prešov,Prešovský,Sabinov,Jakovany,342,8,2.34%,300,2,0.67%
-Topoľčany,Trenčiansky,Prievidza,Rudnianská Lehota,513,12,2.34%,458,1,0.22%
-Trebišov,Košický,Košice - okolie,Herľany,171,4,2.34%,,,
-Prešov,Prešovský,Prešov,Brežany,214,5,2.34%,168,1,0.60%
-Žilina,Žilinský,Čadca,Staškov,2055,48,2.34%,1953,26,1.33%
-Prešov,Prešovský,Sabinov,Jakubova Voľa,257,6,2.33%,242,4,1.65%
-Žilina,Žilinský,Čadca,Radôstka,645,15,2.33%,591,1,0.17%
-Martin,Žilinský,Turčianske Teplice,Blažovce,215,5,2.33%,185,0,0.00%
-Topoľčany,Trenčiansky,Partizánske,Nadlice,691,16,2.32%,629,3,0.48%
-Ružomberok,Žilinský,Liptovský Mikuláš,Pavčina Lehota,476,11,2.31%,435,3,0.69%
-Žilina,Žilinský,Čadca,Svrčinovec,1780,41,2.30%,1799,26,1.45%
-Topoľčany,Trenčiansky,Prievidza,Radobica,478,11,2.30%,482,4,0.83%
-Trenčín,Trenčiansky,Púchov,Nimnica,739,17,2.30%,689,12,1.74%
-Topoľčany,Trenčiansky,Partizánske,Malé Bielice,174,4,2.30%,214,2,0.93%
-Michalovce,Prešovský,Humenné,Kamenica nad Cirochou,1306,30,2.30%,1276,7,0.55%
-Trenčín,Trenčiansky,Trenčín,Svinná,1045,24,2.30%,1053,8,0.76%
-Michalovce,Prešovský,Snina,Hostovice,392,9,2.30%,307,0,0.00%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Rybany,610,14,2.30%,795,9,1.13%
-Trebišov,Košický,Košice - okolie,Štós,480,11,2.29%,,,
-Prešov,Prešovský,Bardejov,Poliakovce,131,3,2.29%,228,2,0.88%
-Trebišov,Košický,Košice - okolie,Vyšná Hutka,262,6,2.29%,,,
-Levice,Nitrianský,Komárno,Sokolce. Brestovec,1358,31,2.28%,,,
-Žilina,Žilinský,Žilina,Konská,966,22,2.28%,930,5,0.54%
-Topoľčany,Trenčiansky,Partizánske,Partizánske,10192,231,2.27%,10932,81,0.74%
-Topoľčany,Nitriansky,Topoľčany,Nemčice,663,15,2.26%,710,8,1.13%
-Martin,Žilinský,Martin,Valča,884,20,2.26%,1003,7,0.70%
-Michalovce,Prešovský,Snina,Ruský Potok,221,5,2.26%,174,0,0.00%
-Prešov,Prešovský,Stará Ľubovňa,Podolínec,1769,40,2.26%,1457,9,0.62%
-Rožňava,Košický,Gelnica,Hrišovce,177,4,2.26%,170,0,0.00%
-Prešov,Prešovský,Bardejov,Hankovce,310,7,2.26%,295,0,0.00%
-Žilina,Žilinský,Kysucké Nové Mesto,Lodno,799,18,2.25%,726,7,0.96%
-Trenčín,Trenčiansky,Myjava,Stará Myjava,533,12,2.25%,635,1,0.16%
-Prešov,Prešovský,Levoča,Domaňovce,622,14,2.25%,595,8,1.34%
-Žilina,Žilinský,Bytča,Predmier,1334,30,2.25%,1116,4,0.36%
-Žilina,Žilinský,Kysucké Nové Mesto,Rudina,1157,26,2.25%,1173,15,1.28%
-Rožňava,Košický,Rimavská Sobota,Rimavské Zalužany,178,4,2.25%,,,
-Michalovce,Košický,Sobrance,Horňa,312,7,2.24%,291,1,0.34%
-Prešov,Prešovský,Stará Ľubovňa,Jakubany,1293,29,2.24%,1218,21,1.72%
-Michalovce,Prešovský,Snina,Snina,8115,182,2.24%,8575,55,0.64%
-Prešov,Prešovský,Prešov,Hendrichovce,223,5,2.24%,213,1,0.47%
-Topoľčany,Trenčiansky,Prievidza,Hradec,357,8,2.24%,480,5,1.04%
-Žilina,Žilinský,Čadca,Podvysoká,1072,24,2.24%,1050,12,1.14%
-Topoľčany,Trenčiansky,Prievidza,Malinová,536,12,2.24%,584,2,0.34%
-Nitra,Nitriansky,Nitra,Hruboňovo,492,11,2.24%,,,
-Prešov,Prešovský,Sabinov,Bodovce,179,4,2.23%,169,1,0.59%
-Prešov,Prešovský,Sabinov,Jakubovany,627,14,2.23%,612,10,1.63%
-Michalovce,Košický,Michalovce,Veľké Raškovce,360,8,2.22%,424,1,0.24%
-Trebišov,Košický,Trebišov,Slivník,497,11,2.21%,,,
-Trenčín,Trenčiansky,Považská Bystrica,Pružina,1401,31,2.21%,1275,14,1.10%
-Prešov,Prešovský,Poprad,Spišská Teplica,1539,34,2.21%,1379,10,0.73%
-Rožňava,Košický,Rimavská Sobota,Tomášovce,272,6,2.21%,,,
-Nitra,Nitriansky,Nitra,Malé Zálužie,182,4,2.20%,,,
-Topoľčany,Trenčiansky,Prievidza,Lehota pod Vtáčnikom,2326,51,2.19%,2414,13,0.54%
-Trenčín,Trenčiansky,Trenčín,Omšenie,1052,23,2.19%,1052,3,0.29%
-Prešov,Prešovský,Poprad,Batizovce,1464,32,2.19%,1298,2,0.15%
-Prešov,Prešovský,Svidník,Kružlová,412,9,2.18%,393,2,0.51%
-Martin,Žilinský,Turčianske Teplice,Dubové,458,10,2.18%,470,4,0.85%
-Martin,Žilinský,Martin,Podhradie,504,11,2.18%,449,1,0.22%
-Michalovce,Košický,Michalovce,Čičarovce,550,12,2.18%,599,3,0.50%
-Žilina,Žilinský,Kysucké Nové Mesto,Rudinská,1012,22,2.17%,799,13,1.63%
-Zvolen,Banskobystrický,Banská Bystrica,Podkonice,552,12,2.17%,539,1,0.19%
-Martin,Žilinský,Námestovo,Hruštín,1798,39,2.17%,1810,5,0.28%
-Prešov,Prešovský,Bardejov,Abrahámovce,323,7,2.17%,278,3,1.08%
-Michalovce,Prešovský,Vranov nad Topľou,Nižný Hrabovec,601,13,2.16%,724,5,0.69%
-Prešov,Prešovský,Stará Ľubovňa,Stará Ľubovňa,8009,173,2.16%,7593,101,1.33%
-Michalovce,Prešovský,Vranov nad Topľou,Nižný Kručov,463,10,2.16%,432,7,1.62%
-Prešov,Prešovský,Sabinov,Olejníkov,418,9,2.15%,377,1,0.27%
-Michalovce,Košický,Sobrance,Jenkovce,372,8,2.15%,364,0,0.00%
-Prešov,Prešovský,Bardejov,Šarišské Čierne,140,3,2.14%,148,2,1.35%
-Ružomberok,Žilinský,Tvrdošín,Hladovka,607,13,2.14%,595,3,0.50%
-Prešov,Prešovský,Bardejov,Zborov,1496,32,2.14%,1646,32,1.94%
-Topoľčany,Nitriansky,Topoľčany,Čermany,187,4,2.14%,312,3,0.96%
-Michalovce,Prešovský,Humenné,Nižné Ladičkovce,375,8,2.13%,346,5,1.45%
-Zvolen,Banskobystrický,Brezno,Závadka nad Hronom,1360,29,2.13%,1209,10,0.83%
-Martin,Žilinský,Martin,Diaková,376,8,2.13%,368,1,0.27%
-Prešov,Prešovský,Prešov,Lažany,517,11,2.13%,117,0,0.00%
-Trebišov,Košický,Košice - okolie,Chorváty,141,3,2.13%,,,
-Prešov,Prešovský,Kežmarok,Vlková,659,14,2.12%,640,7,1.09%
-Žilina,Žilinský,Žilina,Kotrčiná Lúčka,1130,24,2.12%,,,
-Trebišov,Košický,Trebišov,Hrčeľ,521,11,2.11%,,,
-Prešov,Prešovský,Kežmarok,Spišská Stará Ves,1187,25,2.11%,1273,17,1.34%
-Zvolen,Banskobystrický,Banská Štiavnica,Kozelník,95,2,2.11%,,,
-Prešov,Prešovský,Bardejov,Mokroluh,666,14,2.10%,637,5,0.78%
-Sereď,Bratislavský,Senec,Hrubý Šúr,764,16,2.09%,,,
-Trenčín,Trenčiansky,Trenčín,Bobot,575,12,2.09%,428,2,0.47%
-Prešov,Prešovský,Kežmarok,Veľká Lomnica,3115,65,2.09%,3163,26,0.82%
-Žilina,Žilinský,Kysucké Nové Mesto,Kysucké Nové Mesto,8646,180,2.08%,8991,85,0.95%
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Hrachovište,530,11,2.08%,566,7,1.24%
-Topoľčany,Trenčiansky,Prievidza,Nedožery- Brezany,1494,31,2.07%,1310,13,0.99%
-Prešov,Prešovský,Svidník,Kuková,434,9,2.07%,426,2,0.47%
-Michalovce,Prešovský,Snina,Kalná Roztoka,338,7,2.07%,356,0,0.00%
-Trenčín,Trenčiansky,Trenčín,Trenčianska Turná,2077,43,2.07%,2142,9,0.42%
-Levice,Nitriansky,Nové Zámky,Podhájska,727,15,2.06%,,,
-Prešov,Prešovský,Sabinov,Ratvaj,97,2,2.06%,81,1,1.23%
-Topoľčany,Trenčiansky,Prievidza,Poluvsie,534,11,2.06%,493,9,1.83%
-Malacky,Trnavský,Skalica,Lopašov,195,4,2.05%,203,3,1.48%
-Prešov,Prešovský,Kežmarok,Spišská Belá,3708,76,2.05%,3860,27,0.70%
-Prešov,Prešovský,Kežmarok,Vlkovce,342,7,2.05%,323,1,0.31%
-Prešov,Prešovský,Bardejov,Gerlachov,636,13,2.04%,701,6,0.86%
-Rožňava,Košický,Spišská Nová Ves,Hnilčík,392,8,2.04%,437,4,0.92%
-Topoľčany,Nitriansky,Topoľčany,Blesovce,196,4,2.04%,216,0,0.00%
-Sereď,Trnavský,Dunajská Streda,Dolný Štál,1520,31,2.04%,1600,9,0.56%
-Sereď,Trnavský,Dunajská Streda,Vydrany,981,20,2.04%,1216,2,0.16%
-Ružomberok,Žilinský,Liptovský Mikuláš,Liptovský Ondrej,736,15,2.04%,813,1,0.12%
-Prešov,Prešovský,Bardejov,Andrejová,344,7,2.03%,247,3,1.21%
-Topoľčany,Nitriansky,Topoľčany,Kovarce,789,16,2.03%,969,6,0.62%
-Topoľčany,Trenčiansky,Prievidza,Nitrianské Súčany,740,15,2.03%,731,10,1.37%
-Prešov,Prešovský,Sabinov,Ľutina,296,6,2.03%,304,0,0.00%
-Trenčín,Trenčiansky,Ilava,Červený Kameň,543,11,2.03%,495,5,1.01%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Uhrovec,1038,21,2.02%,969,10,1.03%
-Topoľčany,Trenčiansky,Prievidza,Oslany,1138,23,2.02%,1182,4,0.34%
-Prešov,Prešovský,Poprad,Mlynica,547,11,2.01%,457,2,0.44%
-Michalovce,Prešovský,Humenné,Ohradzany,398,8,2.01%,400,8,2.00%
-Prešov,Prešovský,Sabinov,Červená Voda,398,8,2.01%,324,6,1.85%
-Malacky,Trnavský,Senica,Prietrž,797,16,2.01%,712,3,0.42%
-Michalovce,Košický,Michalovce,Vysoká nad Uhom,549,11,2.00%,551,0,0.00%
-Prešov,Prešovský,Sabinov,Lipany,3096,62,2.00%,3256,32,0.98%
-Prešov,Prešovský,Kežmarok,Abrahámovce,100,2,2.00%,255,0,0.00%
-Martin,Žilinský,Martin,Košťany nad Turcom,1053,21,1.99%,937,6,0.64%
-Michalovce,Prešovský,Humenné,Ptičie,502,10,1.99%,357,4,1.12%
-Prešov,Prešovský,Sabinov,Dubovica,754,15,1.99%,765,3,0.39%
-Topoľčany,Trenčiansky,Prievidza,Prievidza,21101,419,1.99%,22640,187,0.83%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Veľké Hoste,403,8,1.99%,393,7,1.78%
-Rožňava,Košický,Spišská Nová Ves,Spišské Tomášovce,1260,25,1.98%,1212,14,1.16%
-Ružomberok,Žilinský,Ružomberok,Liptovská Osada,1059,21,1.98%,1041,4,0.38%
-Michalovce,Prešovský,Humenné,Jasenov,1009,20,1.98%,1032,12,1.16%
-Michalovce,Prešovský,Snina,Stakčínska Roztoka,404,8,1.98%,284,4,1.41%
-Michalovce,Košický,Sobrance,Nižné Nemecké,404,8,1.98%,394,1,0.25%
-Rožňava,Košický,Spišská Nová Ves,Smižany,4755,94,1.98%,4536,44,0.97%
-Prešov,Prešovský,Stará Ľubovňa,Veľký Lipník,506,10,1.98%,473,8,1.69%
-Michalovce,Prešovský,Vranov nad Topľou,Komárany,509,10,1.96%,389,3,0.77%
-Prešov,Prešovský,Poprad,Hôrka,1324,26,1.96%,1290,7,0.54%
-Žilina,Žilinský,Kysucké Nové Mesto,Horný Vadičov,1070,21,1.96%,1090,4,0.37%
-Prešov,Prešovský,Kežmarok,Zálesie,51,1,1.96%,75,4,5.33%
-Trenčín,Trenčiansky,Považská Bystrica,STUPNÉ,510,10,1.96%,538,6,1.12%
-Topoľčany,Trenčiansky,Prievidza,Horné Vestenice,562,11,1.96%,539,2,0.37%
-Martin,Žilinský,Námestovo,Oravská Polhora,2355,46,1.95%,2327,15,0.64%
-Prešov,Prešovský,Sabinov,Hanigovce,256,5,1.95%,175,3,1.71%
-Žilina,Žilinský,Žilina,Stráňavy,1334,26,1.95%,1289,5,0.39%
-Prešov,Prešovský,Prešov,Chmeľovec,360,7,1.94%,341,2,0.59%
-Nitra,Nitriansky,Nitra,Tajná,360,7,1.94%,,,
-Rožňava,Košický,Poltár,Hrnčiarska Ves,463,9,1.94%,,,
-Rožňava,Košický,Rožňava,Rudná,567,11,1.94%,,,
-Prešov,Prešovský,Poprad,Štôla,464,9,1.94%,418,1,0.24%
-Sereď,Trnavský,Dunajská Streda,Sap,361,7,1.94%,411,4,0.97%
-Michalovce,Prešovský,Humenné,Košarovce,620,12,1.94%,627,7,1.12%
-Malacky,Trnavský,Skalica,Petrova Ves,827,16,1.93%,830,4,0.48%
-Martin,Žilinský,Martin,Žabokreky,988,19,1.92%,867,22,2.54%
-Zvolen,Banskobystrický,Banská Bystrica,Horné Pršany,416,8,1.92%,429,1,0.23%
-Prešov,Prešovský,Bardejov,Brezovka,52,1,1.92%,56,0,0.00%
-Levice,Nitrianský,Levice,Horné Semerovce. Slatina,522,10,1.92%,,,
-Michalovce,Košický,Sobrance,Úbrež,470,9,1.91%,447,4,0.89%
-Trenčín,Trenčiansky,Považská Bystrica,PAPRADNO,1360,26,1.91%,1362,21,1.54%
-Levice,Nitriansky,Nové Zámky,Malá n/Hronom,471,9,1.91%,,,
-Zvolen,Banskobystrický,Brezno,Heľpa,1364,26,1.91%,1382,12,0.87%
-Prešov,Prešovský,Kežmarok,Výborná,893,17,1.90%,813,6,0.74%
-Trenčín,Trenčiansky,Považská Bystrica,Jasenica,894,17,1.90%,848,9,1.06%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Bánovce nad Bebravou,8839,168,1.90%,9201,82,0.89%
-Prešov,Prešovský,Svidník,Kurimka,158,3,1.90%,178,0,0.00%
-Topoľčany,Trenčiansky,Prievidza,Valaská Belá,1265,24,1.90%,1312,15,1.14%
-Topoľčany,Trenčiansky,Partizánske,Veľké Uherce,1269,24,1.89%,1397,8,0.57%
-Žilina,Žilinský,Žilina,Divina,1641,31,1.89%,1614,0,0.00%
-Hlohovec,Trnavský,Trnava,Dlhá,424,8,1.89%,,,
-Prešov,Prešovský,Bardejov,Beloveža,584,11,1.88%,538,5,0.93%
-Zvolen,Banskobystrický,Banská Bystrica,Selce,1593,30,1.88%,1415,5,0.35%
-Topoľčany,Trenčiansky,Prievidza,Sebedražie,1009,19,1.88%,1104,3,0.27%
-Michalovce,Prešovský,Humenné,Modra nad Cirochou,585,11,1.88%,555,2,0.36%
-Prešov,Prešovský,Prešov,Žehňa,798,15,1.88%,731,6,0.82%
-Prešov,Prešovský,Kežmarok,Kežmarok,8193,154,1.88%,8823,61,0.69%
-Prešov,Prešovský,Sabinov,Ražňany,1120,21,1.88%,966,10,1.04%
-Prešov,Prešovský,Prešov,Zlatá Baňa,320,6,1.88%,323,2,0.62%
-Trenčín,Trenčiansky,Ilava,Tuchyňa,589,11,1.87%,602,5,0.83%
-Trenčín,Trenčiansky,Považská Bystrica,Brvnište,857,16,1.87%,780,9,1.15%
-Topoľčany,Trenčiansky,Prievidza,Zemianske Kostoľany,857,16,1.87%,891,7,0.79%
-Prešov,Prešovský,Levoča,Levoča,6243,116,1.86%,6356,83,1.31%
-Prešov,Prešovský,Stará Ľubovňa,Hniezdne,646,12,1.86%,660,2,0.30%
-Martin,Žilinský,Dolný Kubín,Dlhá nad Oravou,755,14,1.85%,779,7,0.90%
-Prešov,Prešovský,Stropkov,Brusnica,162,3,1.85%,157,1,0.64%
-Prešov,Prešovský,Sabinov,Uzovce,432,8,1.85%,405,2,0.49%
-Žilina,Žilinský,Kysucké Nové Mesto,Ochodnica,542,10,1.85%,628,3,0.48%
-Sereď,Trnavský,Dunajská Streda,Kostolné Kračany,978,18,1.84%,1045,18,1.72%
-Martin,Žilinský,Martin,Sklabinský Podzámok,326,6,1.84%,281,2,0.71%
-Martin,Žilinský,Námestovo,Beňadovo,653,12,1.84%,641,10,1.56%
-Žilina,Žilinský,Žilina,Dolná Tižina,817,15,1.84%,866,2,0.23%
-Zvolen,Banskobystrický,Brezno,Jasenie,655,12,1.83%,719,8,1.11%
-Prešov,Prešovský,Poprad,Veľký Slavkov,765,14,1.83%,779,6,0.77%
-Trenčín,Trenčiansky,Považská Bystrica,Udiča,1423,26,1.83%,1290,18,1.40%
-Michalovce,Prešovský,Snina,Ubľa,438,8,1.83%,446,3,0.67%
-Malacky,Trnavský,Skalica,Kátov,603,11,1.82%,576,2,0.35%
-Topoľčany,Nitriansky,Topoľčany,Solčany,1591,29,1.82%,1578,12,0.76%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Dolné Naštice,714,13,1.82%,511,2,0.39%
-Žilina,Žilinský,Žilina,Teplička nad Váhom,2748,50,1.82%,2667,26,0.97%
-Martin,Žilinský,Dolný Kubín,Oravský Podzámok,990,18,1.82%,974,5,0.51%
-Prešov,Prešovský,Sabinov,Hubošovce,275,5,1.82%,267,1,0.37%
-Ružomberok,Žilinský,Ružomberok,Lúčky,935,17,1.82%,967,3,0.31%
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Modrovka,110,2,1.82%,349,1,0.29%
-Prešov,Prešovský,Levoča,Harakovce,165,3,1.82%,,,
-Ružomberok,Žilinský,Ružomberok,Ružomberok,14982,272,1.82%,15152,107,0.71%
-Malacky,Trnavský,Skalica,Vrádište,663,12,1.81%,631,8,1.27%
-Martin,Žilinský,Martin,Belá-Dulice,886,16,1.81%,864,3,0.35%
-Prešov,Prešovský,Sabinov,Uzovské Pekľany,333,6,1.80%,305,0,0.00%
-Martin,Žilinský,Námestovo,Rabčice,1166,21,1.80%,1143,0,0.00%
-Prešov,Prešovský,Prešov,Brestov,278,5,1.80%,306,0,0.00%
-Martin,Žilinský,Námestovo,Oravská Lesná,1892,34,1.80%,2128,8,0.38%
-Topoľčany,Nitriansky,Topoľčany,Veľké Bedzany,504,9,1.79%,522,2,0.38%
-Trebišov,Košický,Košice - okolie,Ploské,841,15,1.78%,,,
-Zvolen,Banskobystrický,Lučenec,Mýtna,842,15,1.78%,,,
-Levice,Nitrianský,Komárno,Vrbová nad Váhom,730,13,1.78%,,,
-Prešov,Prešovský,Poprad,Hranovnica,2024,36,1.78%,1886,15,0.80%
-Martin,Žilinský,Dolný Kubín,Horná Lehota,451,8,1.77%,436,5,1.15%
-Prešov,Prešovský,Levoča,Nemešany,451,8,1.77%,352,3,0.85%
-Trenčín,Trenčiansky,Ilava,Dulov,677,12,1.77%,652,6,0.92%
-Topoľčany,Trenčiansky,Prievidza,Horná Ves,734,13,1.77%,785,5,0.64%
-Prešov,Prešovský,Levoča,Granč - Petrovce,509,9,1.77%,452,5,1.11%
-Žilina,Žilinský,Žilina,Lutiše,680,12,1.76%,685,5,0.73%
-Ružomberok,Žilinský,Tvrdošín,Habovka,738,13,1.76%,819,4,0.49%
-Prešov,Prešovský,Poprad,Liptovská Teplička,1594,28,1.76%,1516,8,0.53%
-Topoľčany,Trenčiansky,Prievidza,Bojnice,3247,57,1.76%,2991,12,0.40%
-Prešov,Prešovský,Bardejov,Harhaj,114,2,1.75%,141,1,0.71%
-Prešov,Prešovský,Kežmarok,Osturňa,285,5,1.75%,292,1,0.34%
-Prešov,Prešovský,Levoča,Beharovce,114,2,1.75%,212,0,0.00%
-Prešov,Prešovský,Prešov,Drienovská Nová Ves,628,11,1.75%,947,5,0.53%
-Michalovce,Košický,Michalovce,Bracovce,571,10,1.75%,578,0,0.00%
-Prešov,Prešovský,Kežmarok,Tvarožná,574,10,1.74%,526,3,0.57%
-Martin,Žilinský,Martin,Trnovo,345,6,1.74%,303,0,0.00%
-Martin,Žilinský,Námestovo,Zubrohlava,1095,19,1.74%,1185,8,0.68%
-Sereď,Trnavský,Dunajská Streda,Okoč,2481,43,1.73%,3534,29,0.82%
-Žilina,Žilinský,Žilina,Rajecké Teplice,2138,37,1.73%,2117,17,0.80%
-Prešov,Prešovský,Prešov,Bzenov,578,10,1.73%,567,0,0.00%
-Topoľčany,Nitriansky,Topoľčany,Topoľčany,13874,240,1.73%,14242,89,0.62%
-Michalovce,Košický,Sobrance,Choňkovce,579,10,1.73%,561,1,0.18%
-Prešov,Prešovský,Poprad,Svit,3951,68,1.72%,3591,18,0.50%
-Trenčín,Trenčiansky,Trenčín,Mníchova Lehota,930,16,1.72%,911,10,1.10%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Veľké Držkovce,465,8,1.72%,475,3,0.63%
-Trenčín,Trenčiansky,Trenčín,Selec,816,14,1.72%,676,5,0.74%
-Zvolen,Banskobystrický,Detva,Stožok,816,14,1.72%,792,2,0.25%
-Trenčín,Trenčiansky,Považská Bystrica,Čelkova Lehota,175,3,1.71%,152,2,1.32%
-Topoľčany,Nitriansky,Topoľčany,Podhradie,175,3,1.71%,198,0,0.00%
-Malacky,Trnavský,Senica,Smolinské,702,12,1.71%,765,4,0.52%
-Ružomberok,Žilinský,Tvrdošín,Zuberec,1171,20,1.71%,1235,4,0.32%
-Trebišov,Košický,Košice - okolie,Mokrance,820,14,1.71%,,,
-Rožňava,Košický,Rimavská Sobota,Gortva,293,5,1.71%,,,
-Zvolen,Banskobystrický,Žarnovica,Malá Lehota,586,10,1.71%,,,
-Prešov,Prešovský,Levoča,Nižné Repaše,176,3,1.70%,154,0,0.00%
-Martin,Žilinský,Námestovo,Novoť,1878,32,1.70%,1997,22,1.10%
-Rožňava,Košický,Rimavská Sobota,Tachty,294,5,1.70%,,,
-Martin,Žilinský,Námestovo,Námestovo,5120,87,1.70%,5192,19,0.37%
-Michalovce,Prešovský,Snina,Pčoliné,412,7,1.70%,423,3,0.71%
-Martin,Žilinský,Dolný Kubín,Zaškov,942,16,1.70%,980,6,0.61%
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Lúka,530,9,1.70%,771,3,0.39%
-Zvolen,Banskobystrický,Banská Bystrica,Medzibrod,1061,18,1.70%,963,6,0.62%
-Zvolen,Banskobystrický,Brezno,Valaská,1829,31,1.69%,1905,21,1.10%
-Malacky,Trnavský,Skalica,Koválovec,118,2,1.69%,147,1,0.68%
-Martin,Žilinský,Turčianske Teplice,Budiš,177,3,1.69%,186,0,0.00%
-Sereď,Trnavský,Dunajská Streda,Veľká Paka,888,15,1.69%,892,2,0.22%
-Hlohovec,Trnavský,Trnava,Košolná,533,9,1.69%,,,
-Prešov,Prešovský,Stropkov,Vyšná Olšava,356,6,1.69%,346,2,0.58%
-Topoľčany,Trenčiansky,Prievidza,Dolné Vestenice,1428,24,1.68%,1514,4,0.26%
-Malacky,Trnavský,Skalica,Dubovce,655,11,1.68%,505,2,0.40%
-Ružomberok,Žilinský,Liptovský Mikuláš,Vavrišovo,657,11,1.67%,614,1,0.16%
-Martin,Žilinský,Dolný Kubín,Zázrivá,1497,25,1.67%,1652,17,1.03%
-Topoľčany,Nitriansky,Topoľčany,Ludanice,1019,17,1.67%,1198,5,0.42%
-Žilina,Žilinský,Žilina,Dlhé Pole,1620,27,1.67%,1470,6,0.41%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Chudá Lehota,180,3,1.67%,191,0,0.00%
-Prešov,Prešovský,Stará Ľubovňa,Ďurková,60,1,1.67%,89,0,0.00%
-Žilina,Žilinský,Žilina,Varín,2288,38,1.66%,2415,11,0.46%
-Topoľčany,Nitriansky,Topoľčany,Bzince,242,4,1.65%,113,0,0.00%
-Topoľčany,Nitriansky,Topoľčany,Kamanová,666,11,1.65%,873,3,0.34%
-Martin,Žilinský,Martin,Sklabiňa,424,7,1.65%,437,5,1.14%
-Ružomberok,Žilinský,Ružomberok,Komjatná,850,14,1.65%,828,5,0.60%
-Topoľčany,Trenčiansky,Prievidza,Koš,790,13,1.65%,776,7,0.90%
-Žilina,Žilinský,Bytča,Hlboké nad Váhom,1094,18,1.65%,870,10,1.15%
-Žilina,Žilinský,Bytča,Bytča,6932,114,1.64%,7009,78,1.11%
-Topoľčany,Trenčiansky,Prievidza,Pravenec,1035,17,1.64%,920,8,0.87%
-Prešov,Prešovský,Stropkov,Vyškovce,122,2,1.64%,108,3,2.78%
-Prešov,Prešovský,Prešov,Tulčík,793,13,1.64%,774,3,0.39%
-Ružomberok,Žilinský,Tvrdošín,Tvrdošín,4699,77,1.64%,4927,46,0.93%
-Sereď,Trnavský,Dunajská Streda,Gabčíkovo,3479,57,1.64%,3839,12,0.31%
-Prešov,Prešovský,Poprad,Spišské Bystré,1715,28,1.63%,1609,11,0.68%
-Topoľčany,Nitriansky,Topoľčany,Súlovce,429,7,1.63%,615,3,0.49%
-Michalovce,Prešovský,Snina,Šmigovec,184,3,1.63%,418,0,0.00%
-Prešov,Prešovský,Stará Ľubovňa,Mníšek nad Popradom,246,4,1.63%,385,9,2.34%
-Prešov,Prešovský,Prešov,Malý Šariš,1230,20,1.63%,1200,2,0.17%
-Levice,Nitrianský,Komárno,Bodza. Holiare. Lipové,861,14,1.63%,,,
-Trenčín,Trenčiansky,Považská Bystrica,PLEVNÍK-DRIENOVÉ,1232,20,1.62%,1042,9,0.86%
-Prešov,Prešovský,Kežmarok,Huncovce,1849,30,1.62%,1723,11,0.64%
-Zvolen,Banskobystrický,Banská Bystrica,Nemce,863,14,1.62%,833,7,0.84%
-Prešov,Prešovský,Bardejov,Vaniškovce,247,4,1.62%,173,1,0.58%
-Trebišov,Košický,Košice - okolie,Ždaňa,803,13,1.62%,,,
-Michalovce,Prešovský,Humenné,Humenné,13599,220,1.62%,14657,77,0.53%
-Zvolen,Banskobystrický,Banská Bystrica,Vlkanová,990,16,1.62%,1012,5,0.49%
-Prešov,Prešovský,Svidník,Vyšný Mirošov,310,5,1.61%,304,2,0.66%
-Prešov,Prešovský,Stará Ľubovňa,Chmeľnica,558,9,1.61%,589,2,0.34%
-Prešov,Prešovský,Levoča,Studenec,186,3,1.61%,188,0,0.00%
-Zvolen,Banskobystrický,Žiar nad Hronom,Sklené Teplice,434,7,1.61%,,,
-Zvolen,Banskobystrický,Brezno,Pohorelá - Maša,248,4,1.61%,,,
-Zvolen,Banskobystrický,Žarnovica,Veľká Lehota,931,15,1.61%,,,
-Prešov,Prešovský,Prešov,Kapušany,1495,24,1.61%,1466,2,0.14%
-Sereď,Trnavský,Galanta,Trstice,2682,43,1.60%,,,
-Martin,Žilinský,Martin,Kláštor pod Znievom,874,14,1.60%,925,13,1.41%
-Topoľčany,Nitriansky,Topoľčany,Jacovce,937,15,1.60%,1052,4,0.38%
-Prešov,Prešovský,Stropkov,Potoky,125,2,1.60%,120,1,0.83%
-Prešov,Prešovský,Prešov,Veľký Slivník,188,3,1.60%,175,2,1.14%
-Michalovce,Prešovský,Snina,Ulič,628,10,1.59%,605,1,0.17%
-Michalovce,Prešovský,Vranov nad Topľou,Rudlov,503,8,1.59%,460,2,0.43%
-Sereď,Trnavský,Dunajská Streda,Pataš,566,9,1.59%,701,4,0.57%
-Prešov,Prešovský,Bardejov,Hažlín,566,9,1.59%,591,1,0.17%
-Žilina,Žilinský,Bytča,Jablonové,693,11,1.59%,712,6,0.84%
-Nitra,Nitriansky,Zlaté Moravce,Jedľové Kostoľany,694,11,1.59%,,,
-Prešov,Prešovský,Stará Ľubovňa,Malý Lipník,253,4,1.58%,230,5,2.17%
-Sereď,Trnavský,Dunajská Streda,Padáň,759,12,1.58%,740,1,0.14%
-Topoľčany,Trenčiansky,Prievidza,Cígeľ,1013,16,1.58%,883,6,0.68%
-Zvolen,Banskobystrický,Detva,Hriňová,4053,64,1.58%,4311,18,0.42%
-Prešov,Prešovský,Kežmarok,Vojňany,190,3,1.58%,183,4,2.19%
-Trenčín,Trenčiansky,Trenčín,Trenčianske Mitice,570,9,1.58%,563,6,1.07%
-Prešov,Prešovský,Bardejov,Krivé,190,3,1.58%,164,1,0.61%
-Žilina,Žilinský,Žilina,Mojš,1268,20,1.58%,1215,4,0.33%
-Ružomberok,Žilinský,Ružomberok,Liptovská Štiavnica,761,12,1.58%,762,9,1.18%
-Prešov,Prešovský,Levoča,Úloža,127,2,1.57%,145,3,2.07%
-Prešov,Prešovský,Prešov,Okružná,381,6,1.57%,365,3,0.82%
-Topoľčany,Trenčiansky,Partizánske,Návojovce,445,7,1.57%,403,3,0.74%
-Ružomberok,Žilinský,Liptovský Mikuláš,Pribylina,954,15,1.57%,977,2,0.20%
-Trenčín,Trenčiansky,Ilava,Ladce,1659,26,1.57%,1669,17,1.02%
-Martin,Žilinský,Martin,Rakovo,447,7,1.57%,386,1,0.26%
-Topoľčany,Nitriansky,Topoľčany,Krnča,895,14,1.56%,908,7,0.77%
-Martin,Žilinský,Námestovo,Bobrov,1152,18,1.56%,1273,8,0.63%
-Zvolen,Banskobystrický,Brezno,Horná Lehota,512,8,1.56%,480,2,0.42%
-Trenčín,Trenčiansky,Ilava,Košecké Podhradie,768,12,1.56%,729,3,0.41%
-Michalovce,Prešovský,Vranov nad Topľou,Dlhé Klčovo,704,11,1.56%,768,2,0.26%
-Prešov,Prešovský,Sabinov,Daletice,386,6,1.55%,71,0,0.00%
-Zvolen,Banskobystrický,Veľký Krtíš,Sečianky,193,3,1.55%,,,
-Hlohovec,Trnavský,Trnava,Trstín,838,13,1.55%,,,
-Ružomberok,Žilinský,Liptovský Mikuláš,Jakubovany,516,8,1.55%,424,5,1.18%
-Žilina,Žilinský,Čadca,Dunajov,839,13,1.55%,748,3,0.40%
-Prešov,Prešovský,Bardejov,Koprivnica,452,7,1.55%,433,5,1.15%
-Topoľčany,Nitriansky,Topoľčany,Hajnej Novej Vsi,452,7,1.55%,400,4,1.00%
-Martin,Žilinský,Martin,Ratkovo,452,7,1.55%,297,2,0.67%
-Prešov,Prešovský,Sabinov,Jarovnice,4004,62,1.55%,3761,51,1.36%
-Ružomberok,Žilinský,Ružomberok,Ľubochňa,840,13,1.55%,811,7,0.86%
-Nitra,Nitriansky,Nitra,Čab,711,11,1.55%,,,
-Ružomberok,Žilinský,Ružomberok,Liptovská Teplá,582,9,1.55%,618,5,0.81%
-Prešov,Prešovský,Svidník,Lúčka,388,6,1.55%,336,2,0.60%
-Malacky,Trnavský,Skalica,Kopčany,1877,29,1.55%,1889,18,0.95%
-Malacky,Trnavský,Senica,Kuklov,713,11,1.54%,699,4,0.57%
-Topoľčany,Trenčiansky,Partizánske,Malé Krštenany,650,10,1.54%,535,9,1.68%
-Prešov,Prešovský,Kežmarok,Malý Slavkov,780,12,1.54%,760,1,0.13%
-Prešov,Prešovský,Levoča,Klčov,586,9,1.54%,462,9,1.95%
-Michalovce,Prešovský,Snina,Klenová,456,7,1.54%,374,0,0.00%
-Martin,Žilinský,Námestovo,Klin,1239,19,1.53%,1386,7,0.51%
-Levice,Nitriansky,Nové Zámky,Mojzesovo,913,14,1.53%,,,
-Žilina,Žilinský,Žilina,Zbyňov,914,14,1.53%,793,8,1.01%
-Martin,Žilinský,Námestovo,Ťapešovo,719,11,1.53%,600,4,0.67%
-Prešov,Prešovský,Bardejov,Bardejov,14398,220,1.53%,15718,112,0.71%
-Sereď,Trnavský,Dunajská Streda,Veľký Meder,5305,81,1.53%,7709,63,0.82%
-Trebišov,Košický,Košice - okolie,Rankovce,657,10,1.52%,,,
-Martin,Žilinský,Martin,Vrútky,4870,74,1.52%,5222,38,0.73%
-Trenčín,Trenčiansky,Trenčín,Horňany,264,4,1.52%,232,4,1.72%
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Čachtice,2378,36,1.51%,2699,15,0.56%
-Topoľčany,Trenčiansky,Partizánske,Kolačno,529,8,1.51%,574,11,1.92%
-Ružomberok,Žilinský,Ružomberok,Liptovská Lúžna,1524,23,1.51%,1577,4,0.25%
-Sereď,Trnavský,Dunajská Streda,Trnávka,398,6,1.51%,475,2,0.42%
-Topoľčany,Trenčiansky,Prievidza,Handlová,8697,131,1.51%,9248,73,0.79%
-Prešov,Prešovský,Sabinov,Brezovica,1196,18,1.51%,1068,5,0.47%
-Ružomberok,Žilinský,Liptovský Mikuláš,Bobrovník,400,6,1.50%,358,6,1.68%
-Trenčín,Trenčiansky,Trenčín,Trenčianske Teplice,2545,38,1.49%,2702,14,0.52%
-Rožňava,Košický,Rožňava,Nižná Slaná,807,12,1.49%,,,
-Martin,Žilinský,Dolný Kubín,Dolný Kubín,10430,155,1.49%,10262,57,0.56%
-Prešov,Prešovský,Kežmarok,Stráne pod Tatrami,1077,16,1.49%,998,6,0.60%
-Topoľčany,Trenčiansky,Prievidza,Veľká Čausa,404,6,1.49%,380,2,0.53%
-Ružomberok,Žilinský,Liptovský Mikuláš,Závažná Poruba,808,12,1.49%,832,3,0.36%
-Rožňava,Košický,Rimavská Sobota,Orávka,202,3,1.49%,,,
-Trenčín,Trenčiansky,Ilava,Bohunice,539,8,1.48%,521,2,0.38%
-Trenčín,Trenčiansky,Trenčín,Dolná Súča,2025,30,1.48%,2455,7,0.29%
-Topoľčany,Trenčiansky,Prievidza,Chrenovec-Brusno,1219,18,1.48%,898,7,0.78%
-Sereď,Trnavský,Dunajská Streda,Jurová,339,5,1.47%,604,3,0.50%
-Prešov,Prešovský,Sabinov,Šarišské Michaľany,1837,27,1.47%,1811,8,0.44%
-Topoľčany,Nitriansky,Topoľčany,Krušovce,885,13,1.47%,929,3,0.32%
-Nitra,Nitriansky,Šaľa,Selice,1431,21,1.47%,,,
-Topoľčany,Nitriansky,Topoľčany,Chrabrany,682,10,1.47%,673,8,1.19%
-Martin,Žilinský,Námestovo,Sihelné,1228,18,1.47%,1182,7,0.59%
-Žilina,Žilinský,Žilina,Krasňany,1092,16,1.47%,1068,6,0.56%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Slatina nad Bebravou,205,3,1.46%,206,4,1.94%
-Žilina,Žilinský,Žilina,Jasenové,615,9,1.46%,494,1,0.20%
-Prešov,Prešovský,Stará Ľubovňa,Ľubotín,480,7,1.46%,644,12,1.86%
-Malacky,Trnavský,Skalica,Prietržka,686,10,1.46%,533,2,0.38%
-Prešov,Prešovský,Bardejov,Šiba,412,6,1.46%,380,2,0.53%
-Zvolen,Banskobystrický,Brezno,Polomka,1719,25,1.45%,1883,16,0.85%
-Žilina,Žilinský,Kysucké Nové Mesto,Nesluša,1788,26,1.45%,1917,11,0.57%
-Malacky,Trnavský,Skalica,Oreské,414,6,1.45%,347,3,0.86%
-Sereď,Trnavský,Dunajská Streda,Malé Dvorníky,1174,17,1.45%,1225,8,0.65%
-Michalovce,Prešovský,Humenné,Kochanovce,622,9,1.45%,579,1,0.17%
-Topoľčany,Trenčiansky,Prievidza,Kľačno,693,10,1.44%,720,0,0.00%
-Trebišov,Košický,Trebišov,Dargov,416,6,1.44%,,,
-Ružomberok,Žilinský,Liptovský Mikuláš,Liptovský Mikuláš,17835,257,1.44%,18706,107,0.57%
-Topoľčany,Nitriansky,Topoľčany,Hrušovany,764,11,1.44%,1368,18,1.32%
-Malacky,Trnavský,Skalica,Unín,696,10,1.44%,696,9,1.29%
-Ružomberok,Žilinský,Liptovský Mikuláš,Liptovská Porúbka,767,11,1.43%,799,8,1.00%
-Martin,Žilinský,Dolný Kubín,Párnica,628,9,1.43%,661,6,0.91%
-Malacky,Trnavský,Skalica,Holíč,5034,72,1.43%,6243,24,0.38%
-Malacky,Trnavský,Skalica,Popudinské Močidľany,630,9,1.43%,645,1,0.16%
-Malacky,Bratislavský,Pezinok,Vinosady,1122,16,1.43%,,,
-Zvolen,Banskobystrický,Krupina,Hontianske Moravce,421,6,1.43%,,,
-Prešov,Prešovský,Prešov,Čelovce,211,3,1.42%,203,1,0.49%
-Nitra,Nitriansky,Zlaté Moravce,Tekovské Nemce,636,9,1.42%,,,
-Trebišov,Košický,Košice - okolie,Buzica,707,10,1.41%,,,
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Kálnica,710,10,1.41%,727,3,0.41%
-Prešov,Prešovský,Bardejov,Livovská Huta,71,1,1.41%,50,0,0.00%
-Rožňava,Košický,Rožňava,Vlachovo,497,7,1.41%,,,
-Martin,Žilinský,Námestovo,Oravská Jasenica,1211,17,1.40%,1204,4,0.33%
-Prešov,Prešovský,Kežmarok,Ľubica,2707,38,1.40%,2556,24,0.94%
-Žilina,Žilinský,Žilina,Gbeľany,998,14,1.40%,876,10,1.14%
-Ružomberok,Žilinský,Ružomberok,Bešeňová,499,7,1.40%,513,1,0.19%
-Zvolen,Banskobystrický,Banská Bystrica,Ľubietová,857,12,1.40%,837,4,0.48%
-Prešov,Prešovský,Sabinov,Brezovička,143,2,1.40%,155,0,0.00%
-Malacky,Trnavský,Skalica,Brodské,1579,22,1.39%,1696,9,0.53%
-Nitra,Nitriansky,Šaľa,Dlhá,646,9,1.39%,,,
-Zvolen,Banskobystrický,Banská Bystrica,Hrochoť,862,12,1.39%,895,2,0.22%
-Prešov,Prešovský,Bardejov,Petrová,575,8,1.39%,575,8,1.39%
-Michalovce,Prešovský,Humenné,Topoľovka,504,7,1.39%,486,0,0.00%
-Michalovce,Košický,Michalovce,Senné,360,5,1.39%,343,0,0.00%
-Rožňava,Košický,Poltár,Hradište,144,2,1.39%,,,
-Hlohovec,Trnavský,Hlohovec,Pastuchov,649,9,1.39%,,,
-Nitra,Nitriansky,Zlaté Moravce,Hostie,794,11,1.39%,,,
-Zvolen,Banskobystrický,Banská Bystrica,Donovaly,651,9,1.38%,851,1,0.12%
-Trenčín,Trenčiansky,Púchov,Mojtín,435,6,1.38%,430,6,1.40%
-Zvolen,Banskobystrický,Banská Bystrica,Brusno,1305,18,1.38%,1432,9,0.63%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Horné Naštice,435,6,1.38%,374,2,0.53%
-Prešov,Prešovský,Poprad,Poprad,24910,343,1.38%,25615,162,0.63%
-Trenčín,Trenčiansky,Myjava,Brestovec,581,8,1.38%,617,2,0.32%
-Topoľčany,Nitriansky,Topoľčany,Veľké Ripňany,1380,19,1.38%,1812,9,0.50%
-Ružomberok,Žilinský,Liptovský Mikuláš,Dúbrava,799,11,1.38%,844,13,1.54%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Prusy,509,7,1.38%,241,2,0.83%
-Trenčín,Trenčiansky,Ilava,Slavnica,800,11,1.38%,465,7,1.51%
-Michalovce,Prešovský,Snina,Stakčín,1091,15,1.37%,1138,5,0.44%
-Prešov,Prešovský,Svidník,Radoma,291,4,1.37%,262,1,0.38%
-Prešov,Prešovský,Sabinov,Červenica pri Sabinove,582,8,1.37%,579,1,0.17%
-Ružomberok,Žilinský,Tvrdošín,Oravský Biely Potok,510,7,1.37%,539,2,0.37%
-Nitra,Nitriansky,Zlaté Moravce,Nevidzany,510,7,1.37%,,,
-Michalovce,Košický,Michalovce,Malčice,656,9,1.37%,698,3,0.43%
-Prešov,Prešovský,Bardejov,Livov,73,1,1.37%,73,1,1.37%
-Michalovce,Košický,Michalovce,Laškovce,438,6,1.37%,431,1,0.23%
-Zvolen,Banskobystrický,Krupina,Lišov,146,2,1.37%,,,
-Michalovce,Košický,Michalovce,Budkovce,658,9,1.37%,716,7,0.98%
-Topoľčany,Nitriansky,Topoľčany,Velušovce,439,6,1.37%,458,1,0.22%
-Zvolen,Banskobystrický,Banská Bystrica,Králiky,660,9,1.36%,666,1,0.15%
-Hlohovec,Trnavský,Trnava,Križovany nad Dudváhom,1468,20,1.36%,,,
-Zvolen,Banskobystrický,Brezno,Nemecká,1178,16,1.36%,1180,3,0.25%
-Prešov,Prešovský,Prešov,Ľubotice,2067,28,1.35%,2189,9,0.41%
-Ružomberok,Žilinský,Liptovský Mikuláš,Pavlova Ves,443,6,1.35%,379,4,1.06%
-Martin,Žilinský,Turčianske Teplice,Turček,443,6,1.35%,906,0,0.00%
-Michalovce,Prešovský,Snina,Pichne,517,7,1.35%,462,3,0.65%
-Martin,Žilinský,Martin,Horný Kalník,296,4,1.35%,222,5,2.25%
-Rožňava,Košický,Spišská Nová Ves,Iliašovce,741,10,1.35%,631,7,1.11%
-Prešov,Prešovský,Prešov,Terňa,890,12,1.35%,895,4,0.45%
-Malacky,Trnavský,Senica,Hlboké,742,10,1.35%,765,4,0.52%
-Prešov,Prešovský,Prešov,Bretejovce,371,5,1.35%,1261,6,0.48%
-Martin,Žilinský,Martin,Dolný Kalník,372,5,1.34%,344,3,0.87%
-Topoľčany,Nitriansky,Topoľčany,Prašice,1340,18,1.34%,1375,10,0.73%
-Prešov,Prešovský,Levoča,Spišské Podhradie,1864,25,1.34%,1962,9,0.46%
-Trebišov,Košický,Košice - okolie,Kalša,522,7,1.34%,,,
-Topoľčany,Nitriansky,Topoľčany,Kuzmice,597,8,1.34%,400,2,0.50%
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Považany,898,12,1.34%,985,7,0.71%
-Topoľčany,Nitriansky,Topoľčany,Tesáre,524,7,1.34%,489,1,0.20%
-Prešov,Prešovský,Kežmarok,Jurské,900,12,1.33%,808,11,1.36%
-Ružomberok,Žilinský,Liptovský Mikuláš,Ľubeľa,900,12,1.33%,903,2,0.22%
-Topoľčany,Trenčiansky,Partizánske,Chynorany,1428,19,1.33%,1560,10,0.64%
-Rožňava,Košický,Rožňava,Roštár,301,4,1.33%,,,
-Martin,Žilinský,Turčianske Teplice,Ivančiná,151,2,1.32%,158,2,1.27%
-Michalovce,Prešovský,Vranov nad Topľou,Kvakovce,378,5,1.32%,382,2,0.52%
-Michalovce,Košický,Sobrance,Koromľa,378,5,1.32%,348,0,0.00%
-Michalovce,Košický,Michalovce,Ptrukša,303,4,1.32%,301,7,2.33%
-Ružomberok,Žilinský,Liptovský Mikuláš,Liptovský Ján,758,10,1.32%,780,3,0.38%
-Malacky,Trnavský,Senica,Rybky,304,4,1.32%,280,3,1.07%
-Michalovce,Košický,Sobrance,Ostrov,380,5,1.32%,361,0,0.00%
-Trebišov,Košický,Košice - okolie,Nižný Čaj,380,5,1.32%,,,
-Prešov,Prešovský,Kežmarok,Mlynčeky,533,7,1.31%,543,2,0.37%
-Hlohovec,Trnavský,Trnava,Špačince,2362,31,1.31%,,,
-Topoľčany,Nitriansky,Topoľčany,Práznovce,687,9,1.31%,693,4,0.58%
-Žilina,Žilinský,Kysucké Nové Mesto,Kysucký Lieskovec,1375,18,1.31%,1418,8,0.56%
-Prešov,Prešovský,Poprad,Gerlachov,535,7,1.31%,487,1,0.21%
-Žilina,Žilinský,Žilina,Turie,2066,27,1.31%,1869,14,0.75%
-Trebišov,Košický,Trebišov,Bačka,460,6,1.30%,,,
-Prešov,Prešovský,Bardejov,Kobyly,537,7,1.30%,531,5,0.94%
-Trebišov,Košický,Košice - okolie,Gyňov,768,10,1.30%,,,
-Žilina,Žilinský,Bytča,Kotešová,1613,21,1.30%,1619,5,0.31%
-Sereď,Trnavský,Dunajská Streda,Kútniky,999,13,1.30%,1031,3,0.29%
-Rožňava,Košický,Rimavská Sobota,Bátka,615,8,1.30%,,,
-Zvolen,Banskobystrický,Banská Bystrica,Priechod,694,9,1.30%,651,1,0.15%
-Malacky,Trnavský,Skalica,Skalica,8333,108,1.30%,9399,54,0.57%
-Sereď,Trnavský,Dunajská Streda,Horný Bar,1158,15,1.30%,1104,1,0.09%
-Ružomberok,Žilinský,Liptovský Mikuláš,Liptovské Matiašovce,386,5,1.30%,361,0,0.00%
-Zvolen,Banskobystrický,Brezno,Čierny Balog,3092,40,1.29%,3166,18,0.57%
-Malacky,Trnavský,Skalica,Mokrý Háj,544,7,1.29%,512,2,0.39%
-Malacky,Trnavský,Senica,Koválov,622,8,1.29%,570,2,0.35%
-Michalovce,Prešovský,Snina,Belá nad Cirochou,2102,27,1.28%,2044,8,0.39%
-Trenčín,Trenčiansky,Myjava,Poriadie,545,7,1.28%,498,2,0.40%
-Ružomberok,Žilinský,Liptovský Mikuláš,Važec,1402,18,1.28%,1462,7,0.48%
-Prešov,Prešovský,Svidník,Mestisko,234,3,1.28%,243,1,0.41%
-Prešov,Prešovský,Bardejov,Regetovka,234,3,1.28%,155,0,0.00%
-Trebišov,Košický,Košice - okolie,Čečejovce,1721,22,1.28%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Veľká Ves nad Ipľom,313,4,1.28%,,,
-Prešov,Prešovský,Prešov,Fulianka,470,6,1.28%,303,4,1.32%
-Rožňava,Košický,Rimavská Sobota,Dražice,235,3,1.28%,,,
-Zvolen,Banskobystrický,Žiar nad Hronom,Hliník nad Hronom,1491,19,1.27%,,,
-Michalovce,Prešovský,Snina,Zboj,472,6,1.27%,447,0,0.00%
-Trebišov,Košický,Trebišov,Klin nad Bodrogom,315,4,1.27%,,,
-Prešov,Prešovský,Bardejov,Brezov,316,4,1.27%,268,2,0.75%
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Moravské Lieskové,1896,24,1.27%,1807,4,0.22%
-Trenčín,Trenčiansky,Myjava,Jablonka,237,3,1.27%,250,0,0.00%
-Nitra,Nitriansky,Nitra,Čifáre,395,5,1.27%,,,
-Trenčín,Trenčiansky,Ilava,Ilava,3484,44,1.26%,3552,46,1.30%
-Michalovce,Košický,Michalovce,Palín,476,6,1.26%,479,1,0.21%
-Žilina,Žilinský,Žilina,Kamenná Poruba,1191,15,1.26%,1165,3,0.26%
-Trebišov,Košický,Trebišov,Dobrá,397,5,1.26%,,,
-Rožňava,Košický,Rimavská Sobota,Lukovištia,318,4,1.26%,,,
-Prešov,Prešovský,Prešov,Víťaz,1273,16,1.26%,1284,6,0.47%
-Prešov,Prešovský,Stará Ľubovňa,Litmanová,319,4,1.25%,305,2,0.66%
-Rožňava,Košický,Spišská Nová Ves,Slatvina,319,4,1.25%,276,0,0.00%
-Martin,Žilinský,Dolný Kubín,Vyšný Kubín,399,5,1.25%,398,2,0.50%
-Zvolen,Banskobystrický,Brezno,Pohronská Polhora,1038,13,1.25%,1317,3,0.23%
-Prešov,Prešovský,Bardejov,Osikov,639,8,1.25%,651,5,0.77%
-Trebišov,Košický,Košice - okolie,Kráľovce,639,8,1.25%,,,
-Prešov,Prešovský,Sabinov,Renčišov,320,4,1.25%,262,3,1.15%
-Topoľčany,Trenčiansky,Partizánske,Nedanovce,480,6,1.25%,489,1,0.20%
-Prešov,Prešovský,Bardejov,Kríže,80,1,1.25%,84,0,0.00%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Veľké Chlievany,642,8,1.25%,435,8,1.84%
-Prešov,Prešovský,Svidník,Svidník,4173,52,1.25%,4400,29,0.66%
-Trenčín,Trenčiansky,Ilava,Sedmerovec,241,3,1.24%,233,4,1.72%
-Ružomberok,Žilinský,Ružomberok,Liptovské Revúce,884,11,1.24%,918,4,0.44%
-Michalovce,Prešovský,Snina,Čukalovce,322,4,1.24%,300,3,1.00%
-Topoľčany,Trenčiansky,Partizánske,Hradište,646,8,1.24%,637,7,1.10%
-Malacky,Trnavský,Senica,Častkov,323,4,1.24%,545,3,0.55%
-Sereď,Trnavský,Dunajská Streda,Ohrady,1052,13,1.24%,1079,7,0.65%
-Ružomberok,Žilinský,Ružomberok,Potok,81,1,1.23%,91,2,2.20%
-Prešov,Prešovský,Prešov,Sedlice,648,8,1.23%,640,3,0.47%
-Topoľčany,Nitriansky,Topoľčany,Horné Chlebany,162,2,1.23%,176,0,0.00%
-Prešov,Prešovský,Prešov,Lemešany,1297,16,1.23%,2356,12,0.51%
-Prešov,Prešovský,Stará Ľubovňa,Orlov,487,6,1.23%,439,2,0.46%
-Ružomberok,Žilinský,Liptovský Mikuláš,Uhorská Ves,487,6,1.23%,430,1,0.23%
-Zvolen,Banskobystrický,Lučenec,Mikušovce,163,2,1.23%,,,
-Prešov,Prešovský,Levoča,Doľany,327,4,1.22%,342,1,0.29%
-Rožňava,Košický,Spišská Nová Ves,Spišská Nová Ves,17585,215,1.22%,18500,110,0.59%
-Nitra,Nitriansky,Šaľa,Močenok,2045,25,1.22%,,,
-Malacky,Trnavský,Senica,Kúty,2048,25,1.22%,2709,10,0.37%
-Žilina,Žilinský,Bytča,Kolárovice,1065,13,1.22%,1136,12,1.06%
-Trenčín,Trenčiansky,Ilava,Zliechov,410,5,1.22%,456,3,0.66%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Otrhánky,410,5,1.22%,329,1,0.30%
-Žilina,Žilinský,Žilina,Bitarová,820,10,1.22%,674,1,0.15%
-Martin,Žilinský,Dolný Kubín,Medzibrodie n.Oravou,410,5,1.22%,430,0,0.00%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Šišov,410,5,1.22%,366,0,0.00%
-Martin,Žilinský,Námestovo,Oravské Veselé,1806,22,1.22%,1796,8,0.45%
-Nitra,Nitriansky,Nitra,Dolné Leftanovce,1727,21,1.22%,,,
-Martin,Žilinský,Martin,Bystrička,823,10,1.22%,894,5,0.56%
-Prešov,Prešovský,Levoča,Baldovce,247,3,1.21%,215,2,0.93%
-Zvolen,Banskobystrický,Brezno,Predajná,824,10,1.21%,772,2,0.26%
-Topoľčany,Nitriansky,Topoľčany,Oponice,495,6,1.21%,933,10,1.07%
-Sereď,Trnavský,Dunajská Streda,Medveďov,330,4,1.21%,389,1,0.26%
-Martin,Žilinský,Turčianske Teplice,Borcová,165,2,1.21%,174,0,0.00%
-Žilina,Žilinský,Kysucké Nové Mesto,Snežnica,908,11,1.21%,823,7,0.85%
-Trebišov,Košický,Košice - okolie,Peder,248,3,1.21%,,,
-Prešov,Prešovský,Svidník,Kračúnovce,579,7,1.21%,663,3,0.45%
-Prešov,Prešovský,Sabinov,Uzovský Šalgov,580,7,1.21%,525,6,1.14%
-Sereď,Bratislavský,Senec,Reca,1243,15,1.21%,,,
-Prešov,Prešovský,Bardejov,Hertník,664,8,1.20%,652,11,1.69%
-Michalovce,Prešovský,Humenné,Rovné,332,4,1.20%,304,1,0.33%
-Nitra,Nitriansky,Zlaté Moravce,Lovce,498,6,1.20%,,,
-Zvolen,Banskobystrický,Krupina,Súdovce,166,2,1.20%,,,
-Martin,Žilinský,Martin,Sučany,2659,32,1.20%,2842,12,0.42%
-Prešov,Prešovský,Levoča,Dlhé Stráže,416,5,1.20%,376,1,0.27%
-Prešov,Prešovský,Prešov,Široké,1332,16,1.20%,1399,7,0.50%
-Martin,Žilinský,Martin,Martin,26557,319,1.20%,28102,186,0.66%
-Rožňava,Košický,Spišská Nová Ves,Betlanovce,500,6,1.20%,448,9,2.01%
-Nitra,Nitriansky,Zlaté Moravce,Veľké Vozokany,418,5,1.20%,,,
-Žilina,Žilinský,Bytča,Súľov - Hradná,753,9,1.20%,800,5,0.63%
-Prešov,Prešovský,Poprad,Vernár,502,6,1.20%,475,2,0.42%
-Prešov,Prešovský,Poprad,Vysoké Tatry,2678,32,1.19%,3092,13,0.42%
-Zvolen,Banskobystrický,Brezno,Telgárt,1005,12,1.19%,1041,6,0.58%
-Trebišov,Košický,Košice I,Košice - Kavečany,1089,13,1.19%,,,
-Prešov,Prešovský,Bardejov,Hervartov,252,3,1.19%,258,2,0.78%
-Prešov,Prešovský,Kežmarok,Stará Lesná,672,8,1.19%,683,5,0.73%
-Michalovce,Prešovský,Humenné,Závadka,420,5,1.19%,386,2,0.52%
-Rožňava,Košický,Poltár,Veľká Ves,252,3,1.19%,,,
-Michalovce,Prešovský,Vranov nad Topľou,Vranov nad Topľou,9495,113,1.19%,10484,62,0.59%
-Prešov,Prešovský,Kežmarok,Rakúsy,1935,23,1.19%,1872,15,0.80%
-Prešov,Prešovský,Bardejov,Lukov,505,6,1.19%,488,1,0.20%
-Zvolen,Banskobystrický,Žarnovica,Voznica,505,6,1.19%,,,
-Zvolen,Banskobystrický,Krupina,Ladzany,337,4,1.19%,,,
-Zvolen,Banskobystrický,Detva,Korytárky,844,10,1.18%,902,4,0.44%
-Rožňava,Košický,Rožňava,Pača,422,5,1.18%,,,
-Prešov,Prešovský,Svidník,Soboš,169,2,1.18%,127,0,0.00%
-Nitra,Nitriansky,Nitra,Veľké Zálužie,2118,25,1.18%,,,
-Michalovce,Prešovský,Humenné,Hažín nad Cirochou,509,6,1.18%,566,4,0.71%
-Rožňava,Košický,Gelnica,Jaklovce,1104,13,1.18%,1285,1,0.08%
-Prešov,Prešovský,Kežmarok,Slovenská Ves,1275,15,1.18%,1173,16,1.36%
-Nitra,Nitriansky,Zlaté Moravce,Mankovce,425,5,1.18%,,,
-Michalovce,Prešovský,Humenné,Lackovce,681,8,1.17%,635,3,0.47%
-Trenčín,Trenčiansky,Myjava,Krajné,1022,12,1.17%,1200,8,0.67%
-Nitra,Nitriansky,Nitra,Kapince,341,4,1.17%,,,
-Žilina,Žilinský,Žilina,Lysica,768,9,1.17%,740,0,0.00%
-Zvolen,Banskobystrický,Banská Bystrica,Môlča,256,3,1.17%,270,0,0.00%
-Michalovce,Prešovský,Humenné,Udavské,683,8,1.17%,711,2,0.28%
-Zvolen,Banskobystrický,Detva,Detva,7605,89,1.17%,10210,29,0.28%
-Trenčín,Trenčiansky,Púchov,Beluša - Hloža,428,5,1.17%,436,7,1.61%
-Prešov,Prešovský,Kežmarok,Podhorany,1456,17,1.17%,1859,18,0.97%
-Prešov,Prešovský,Prešov,Lipovce,257,3,1.17%,293,0,0.00%
-Prešov,Prešovský,Bardejov,Sveržov,516,6,1.16%,501,3,0.60%
-Michalovce,Prešovský,Medzilaborce,Čabalovce,172,2,1.16%,185,1,0.54%
-Martin,Žilinský,Martin,Turany,2322,27,1.16%,2558,12,0.47%
-Rožňava,Košický,Spišská Nová Ves,Spišské Vlachy,1549,18,1.16%,1821,21,1.15%
-Ružomberok,Žilinský,Ružomberok,Valaská Dubová,517,6,1.16%,562,29,5.16%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Zlatníky,517,6,1.16%,478,3,0.63%
-Ružomberok,Žilinský,Tvrdošín,Nižná,2244,26,1.16%,2269,9,0.40%
-Prešov,Prešovský,Bardejov,Kľušov,691,8,1.16%,692,3,0.43%
-Trebišov,Košický,Košice - okolie,Háj,173,2,1.16%,,,
-Trebišov,Košický,Košice - okolie,Beniakovce,606,7,1.16%,,,
-Michalovce,Prešovský,Snina,Ladomirov,260,3,1.15%,220,0,0.00%
-Martin,Žilinský,Martin,Lipovec,607,7,1.15%,584,5,0.86%
-Levice,Nitrianský,Levice,Plavé Vozokany,434,5,1.15%,,,
-Martin,Žilinský,Martin,Turčiansky Peter,521,6,1.15%,505,0,0.00%
-Nitra,Nitriansky,Nitra,Zbehy,1650,19,1.15%,,,
-Trenčín,Trenčiansky,Trenčín,Zamarovce,870,10,1.15%,764,6,0.79%
-Nitra,Nitriansky,Zlaté Moravce,Tesárske Mlyňany,957,11,1.15%,,,
-Trebišov,Košický,Košice - okolie,Valaliky,2787,32,1.15%,,,
-Topoľčany,Trenčiansky,Partizánske,Malé Uherce,610,7,1.15%,698,6,0.86%
-Malacky,Trnavský,Senica,Smrdáky,610,7,1.15%,498,2,0.40%
-Topoľčany,Nitriansky,Topoľčany,Norovce,436,5,1.15%,422,2,0.47%
-Prešov,Prešovský,Prešov,Šarišská Poruba,436,5,1.15%,414,0,0.00%
-Sereď,Trnavský,Dunajská Streda,Topoľníky,2096,24,1.15%,2878,19,0.66%
-Michalovce,Košický,Michalovce,Petrikovce,262,3,1.15%,241,0,0.00%
-Topoľčany,Trenčiansky,Prievidza,Nitrica,875,10,1.14%,867,9,1.04%
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Vaďovce,700,8,1.14%,643,6,0.93%
-Michalovce,Prešovský,Vranov nad Topľou,Čaklov,1052,12,1.14%,1319,7,0.53%
-Zvolen,Banskobystrický,Brezno,Šumiac,790,9,1.14%,842,10,1.19%
-Prešov,Prešovský,Svidník,Beňadikovce,88,1,1.14%,86,1,1.16%
-Prešov,Prešovský,Stropkov,Šandal,264,3,1.14%,215,2,0.93%
-Prešov,Prešovský,Svidník,Krajná Porúbka,88,1,1.14%,36,0,0.00%
-Trebišov,Košický,Trebišov,Malá Tŕňa,176,2,1.14%,,,
-Trenčín,Trenčiansky,Púchov,Vydrná,441,5,1.13%,367,6,1.63%
-Sereď,Trnavský,Dunajská Streda,Povoda,1147,13,1.13%,1132,11,0.97%
-Žilina,Žilinský,Žilina,Lietavská Svinná - Babkov,1324,15,1.13%,1242,5,0.40%
-Levice,Nitriansky,Nové Zámky,Šurany,6186,70,1.13%,,,
-Trebišov,Košický,Trebišov,Hriadky,177,2,1.13%,,,
-Martin,Žilinský,Námestovo,Lomná,620,7,1.13%,629,5,0.79%
-Hlohovec,Trnavský,Trnava,Naháč,266,3,1.13%,,,
-Trebišov,Košický,Košice - okolie,Čaňa,3107,35,1.13%,,,
-Michalovce,Košický,Michalovce,Klokočov,444,5,1.13%,452,0,0.00%
-Prešov,Prešovský,Stará Ľubovňa,Hraničné,178,2,1.12%,157,3,1.91%
-Zvolen,Banskobystrický,Brezno,Beňuš,712,8,1.12%,685,5,0.73%
-Nitra,Nitriansky,Nitra,Jelenec,1603,18,1.12%,,,
-Trenčín,Trenčiansky,Ilava,Nová Dubnica,6417,72,1.12%,6435,28,0.44%
-Malacky,Trnavský,Senica,Šaštín - Stráže,2586,29,1.12%,3032,14,0.46%
-Martin,Žilinský,Turčianske Teplice,Abramová,268,3,1.12%,383,0,0.00%
-Trenčín,Trenčiansky,Ilava,Košeca,2597,29,1.12%,1333,21,1.58%
-Prešov,Prešovský,Poprad,Lučivná,807,9,1.12%,630,2,0.32%
-Trenčín,Trenčiansky,Ilava,Dubnica nad Váhom,13370,149,1.11%,13513,113,0.84%
-Trenčín,Trenčiansky,Považská Bystrica,Ďurďové,359,4,1.11%,280,4,1.43%
-Topoľčany,Trenčiansky,Prievidza,Kanianka,1975,22,1.11%,1912,18,0.94%
-Topoľčany,Trenčiansky,Partizánske,Bošany,2336,26,1.11%,2563,11,0.43%
-Malacky,Trnavský,Senica,Podbranč,629,7,1.11%,517,0,0.00%
-Sereď,Trnavský,Galanta,Kajal,989,11,1.11%,,,
-Prešov,Prešovský,Stropkov,Stropkov,4136,46,1.11%,4527,26,0.57%
-Trebišov,Košický,Košice - okolie,Blažice,450,5,1.11%,,,
-Zvolen,Banskobystrický,Brezno,Podbrezová,1894,21,1.11%,2181,14,0.64%
-Rožňava,Košický,Rimavská Sobota,Vlkyňa,361,4,1.11%,,,
-Trebišov,Košický,Trebišov,Hraň,723,8,1.11%,,,
-Michalovce,Prešovský,Humenné,Vyšná Sitnica,452,5,1.11%,450,1,0.22%
-Malacky,Trnavský,Senica,Senica,11490,127,1.11%,12794,71,0.55%
-Michalovce,Prešovský,Medzilaborce,Krásny Brod,362,4,1.10%,425,1,0.24%
-Michalovce,Košický,Michalovce,Maťovské Vojkovce,453,5,1.10%,488,2,0.41%
-Rožňava,Košický,Spišská Nová Ves,Teplička,906,10,1.10%,977,2,0.20%
-Rožňava,Košický,Poltár,Uhorské,272,3,1.10%,,,
-Zvolen,Banskobystrický,Banská Bystrica,Čerín,635,7,1.10%,295,2,0.68%
-Ružomberok,Žilinský,Liptovský Mikuláš,Hybe,998,11,1.10%,1077,2,0.19%
-Zvolen,Banskobystrický,Zvolen,Kováčová,1089,12,1.10%,1164,0,0.00%
-Ružomberok,Žilinský,Ružomberok,Kalameny,364,4,1.10%,332,6,1.81%
-Ružomberok,Žilinský,Liptovský Mikuláš,Beňadiková,273,3,1.10%,268,0,0.00%
-Malacky,Trnavský,Senica,Rohov,547,6,1.10%,313,2,0.64%
-Žilina,Žilinský,Žilina,Svederník,1004,11,1.10%,1045,3,0.29%
-Zvolen,Banskobystrický,Banská Bystrica,Moštenica,274,3,1.09%,283,1,0.35%
-Michalovce,Košický,Michalovce,Pavlovce nad Uhom,1645,18,1.09%,1643,6,0.37%
-Topoľčany,Trenčiansky,Partizánske,Skačany,824,9,1.09%,805,1,0.12%
-Topoľčany,Trenčiansky,Prievidza,Čavoj,550,6,1.09%,596,3,0.50%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Libichava,92,1,1.09%,106,0,0.00%
-Rožňava,Košický,Revúca,Jelšava,1472,16,1.09%,,,
-Zvolen,Banskobystrický,Žiar nad Hronom,Kremnické Bane,184,2,1.09%,,,
-Zvolen,Banskobystrický,Žiar nad Hronom,Kunešov - testuje v Kremnických Baniach,184,2,1.09%,,,
-Trenčín,Trenčiansky,Trenčín,Soblahov,1848,20,1.08%,1699,10,0.59%
-Trenčín,Trenčiansky,Považská Bystrica,Sverepec,1017,11,1.08%,1024,16,1.56%
-Prešov,Prešovský,Bardejov,Lopúchov,185,2,1.08%,212,3,1.42%
-Žilina,Žilinský,Žilina,Rosina,1667,18,1.08%,1780,6,0.34%
-Trenčín,Trenčiansky,Trenčín,Trenčianska Teplá,2594,28,1.08%,2512,13,0.52%
-Zvolen,Banskobystrický,Brezno,Brezno,11583,125,1.08%,12451,78,0.63%
-Prešov,Prešovský,Stará Ľubovňa,Lomnička,1581,17,1.08%,1640,10,0.61%
-Žilina,Žilinský,Žilina,Žilina,48468,521,1.07%,49491,236,0.48%
-Prešov,Prešovský,Kežmarok,Vrbov,840,9,1.07%,799,11,1.38%
-Trebišov,Košický,Trebišov,Lastovce,654,7,1.07%,,,
-Prešov,Prešovský,Sabinov,Pečovská Nová Ves,1682,18,1.07%,1688,8,0.47%
-Rožňava,Košický,Revúca,Ratková,187,2,1.07%,,,
-Martin,Žilinský,Martin,Príbovce,655,7,1.07%,755,5,0.66%
-Prešov,Prešovský,Svidník,Krajné Čierno,94,1,1.06%,71,0,0.00%
-Ružomberok,Žilinský,Liptovský Mikuláš,Vlachy,659,7,1.06%,638,3,0.47%
-Zvolen,Banskobystrický,Brezno,Hronec,755,8,1.06%,656,4,0.61%
-Levice,Nitrianský,Komárno,Martovce,568,6,1.06%,,,
-Topoľčany,Nitriansky,Topoľčany,Preseľany,854,9,1.05%,1390,8,0.58%
-Prešov,Prešovský,Stropkov,Varechovce,95,1,1.05%,85,1,1.18%
-Martin,Žilinský,Námestovo,Krušetnica,665,7,1.05%,638,4,0.63%
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Stará Turá,4656,49,1.05%,5190,45,0.87%
-Trebišov,Košický,Košice - okolie,Skároš,857,9,1.05%,,,
-Prešov,Prešovský,Prešov,Pušovce,381,4,1.05%,350,1,0.29%
-Sereď,Trnavský,Dunajská Streda,Michal na Ostrove,858,9,1.05%,889,1,0.11%
-Prešov,Prešovský,Prešov,Záborské,668,7,1.05%,737,7,0.95%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Pečeňany,191,2,1.05%,240,1,0.42%
-Michalovce,Prešovský,Medzilaborce,Čabiny,382,4,1.05%,350,1,0.29%
-Michalovce,Prešovský,Medzilaborce,Palota,191,2,1.05%,194,0,0.00%
-Zvolen,Banskobystrický,Banská Bystrica,Banská Bystrica,36340,379,1.04%,41007,135,0.33%
-Prešov,Prešovský,Stropkov,Staškovce,192,2,1.04%,196,0,0.00%
-Rožňava,Košický,Gelnica,Smolnícka Huta,384,4,1.04%,481,0,0.00%
-Rožňava,Košický,Gelnica,Kluknava,1057,11,1.04%,1072,12,1.12%
-Topoľčany,Trenčiansky,Prievidza,Nitrianské Pravno,2018,21,1.04%,1966,9,0.46%
-Trenčín,Trenčiansky,Považská Bystrica,Považská Bystrica,19999,208,1.04%,20361,178,0.87%
-Zvolen,Banskobystrický,Detva,Podkriváň,482,5,1.04%,646,3,0.46%
-Zvolen,Banskobystrický,Brezno,Bystrá,482,5,1.04%,470,0,0.00%
-Martin,Žilinský,Martin,Turčianské Kľačany,868,9,1.04%,870,3,0.34%
-Michalovce,Prešovský,Humenné,Nižná Jablonka,193,2,1.04%,209,0,0.00%
-Trebišov,Košický,Trebišov,Sečovce,772,8,1.04%,,,
-Trenčín,Trenčiansky,Myjava,Rudník,676,7,1.04%,662,1,0.15%
-Rožňava,Košický,Spišská Nová Ves,Harichovce,1932,20,1.04%,1620,7,0.43%
-Prešov,Prešovský,Bardejov,Tročany,290,3,1.03%,246,1,0.41%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Pravotice,387,4,1.03%,310,10,3.23%
-Zvolen,Banskobystrický,Žarnovica,Hodruša - Hámre,1454,15,1.03%,,,
-Nitra,Nitriansky,Nitra,Jarok,1745,18,1.03%,,,
-Zvolen,Banskobystrický,Banská Bystrica,Sebedín - Bečov,194,2,1.03%,213,1,0.47%
-Zvolen,Banskobystrický,Banská Štiavnica,Močiar,97,1,1.03%,,,
-Trebišov,Košický,Košice II,Košice - Západ,21931,226,1.03%,,,
-Sereď,Trnavský,Dunajská Streda,Čakany,777,8,1.03%,1208,0,0.00%
-Trebišov,Košický,Košice - okolie,Olšovany,486,5,1.03%,,,
-Nitra,Nitriansky,Nitra,Ivanka pri Nitre,1946,20,1.03%,,,
-Prešov,Prešovský,Prešov,Hermanovce,876,9,1.03%,840,3,0.36%
-Trenčín,Trenčiansky,Považská Bystrica,DOLNÝ LIESKOV,487,5,1.03%,475,3,0.63%
-Topoľčany,Trenčiansky,Partizánske,Klátová nová Ves,1073,11,1.03%,1268,6,0.47%
-Rožňava,Košický,Spišská Nová Ves,Jamník,684,7,1.02%,735,5,0.68%
-Michalovce,Prešovský,Vranov nad Topľou,Benkovce,391,4,1.02%,365,5,1.37%
-Trebišov,Košický,Trebišov,Veľká Tŕňa,391,4,1.02%,,,
-Rožňava,Košický,Spišská Nová Ves,Markušovce,2253,23,1.02%,2311,11,0.48%
-Zvolen,Banskobystrický,Brezno,Pohorelá,980,10,1.02%,1306,8,0.61%
-Zvolen,Banskobystrický,Veľký Krtíš,Bátorová,196,2,1.02%,,,
-Prešov,Prešovský,Poprad,Štrba,2552,26,1.02%,2723,15,0.55%
-Levice,Nitrianský,Levice,Kozárovce,1178,12,1.02%,,,
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Trenčianske Bohuslavice,491,5,1.02%,526,0,0.00%
-Michalovce,Prešovský,Vranov nad Topľou,Ďapalovce,393,4,1.02%,372,0,0.00%
-Levice,Nitrianský,Komárno,Moča,688,7,1.02%,,,
-Žilina,Žilinský,Žilina,Stráža,591,6,1.02%,514,2,0.39%
-Hlohovec,Trnavský,Piešťany,Borovce,789,8,1.01%,,,
-Zvolen,Banskobystrický,Banská Bystrica,Riečka,889,9,1.01%,709,2,0.28%
-Michalovce,Prešovský,Vranov nad Topľou,Kamenná Poruba,494,5,1.01%,857,1,0.12%
-Prešov,Prešovský,Svidník,Giraltovce,1978,20,1.01%,2139,11,0.51%
-Trenčín,Trenčiansky,Trenčín,Trenčín,32865,332,1.01%,32990,202,0.61%
-Topoľčany,Trenčiansky,Partizánske,Brodzany,594,6,1.01%,643,2,0.31%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Dubnička,99,1,1.01%,111,0,0.00%
-Prešov,Prešovský,Bardejov,Nižný Tvarožec,297,3,1.01%,286,0,0.00%
-Prešov,Prešovský,Prešov,Prešov,41406,418,1.01%,44309,188,0.42%
-Malacky,Bratislavský,Malacky,Plavecký Mikuláš,595,6,1.01%,,,
-Rožňava,Košický,Spišská Nová Ves,Kolinovce,496,5,1.01%,523,2,0.38%
-Michalovce,Prešovský,Vranov nad Topľou,Kučín,496,5,1.01%,410,0,0.00%
-Trebišov,Košický,Košice - okolie,Hačava,397,4,1.01%,,,
-Topoľčany,Nitriansky,Topoľčany,Dvorany nad Nitrou,596,6,1.01%,735,6,0.82%
-Ružomberok,Žilinský,Ružomberok,Ivachnová,298,3,1.01%,316,1,0.32%
-Trebišov,Košický,Trebišov,Brehov,398,4,1.01%,,,
-Michalovce,Prešovský,Medzilaborce,Medzilaborce,3185,32,1.00%,2663,7,0.26%
-Levice,Nitrianský,Komárno,Radvaň nad Dunajom,697,7,1.00%,,,
-Trebišov,Košický,Trebišov,Parchovany,1096,11,1.00%,,,
-Prešov,Prešovský,Prešov,Chmeľov,598,6,1.00%,594,2,0.34%
-Zvolen,Banskobystrický,Banská Bystrica,Lučatín,598,6,1.00%,564,0,0.00%
-Hlohovec,Trnavský,Trnava,Boleráz,1698,17,1.00%,,,
-Trenčín,Trenčiansky,Považská Bystrica,Prečín,1099,11,1.00%,1062,11,1.04%
-Michalovce,Prešovský,Vranov nad Topľou,Vlača,600,6,1.00%,621,15,2.42%
-Prešov,Prešovský,Prešov,Lada,600,6,1.00%,550,6,1.09%
-Michalovce,Prešovský,Humenné,Koškovce,400,4,1.00%,425,4,0.94%
-Michalovce,Košický,Sobrance,Bežovce,501,5,1.00%,518,3,0.58%
-Trebišov,Košický,Košice - okolie,Nižný Lánec,401,4,1.00%,,,
-Michalovce,Košický,Michalovce,Moravany,602,6,1.00%,637,2,0.31%
-Žilina,Žilinský,Kysucké Nové Mesto,Radoľa,1306,13,1.00%,1314,14,1.07%
-Michalovce,Košický,Sobrance,Podhoroď,402,4,1.00%,401,2,0.50%
-Sereď,Trnavský,Galanta,Topoľnica,704,7,0.99%,,,
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Ruskovce,503,5,0.99%,489,5,1.02%
-Trebišov,Košický,Trebišov,Biel,805,8,0.99%,,,
-Michalovce,Prešovský,Humenné,Slovenská Volová,403,4,0.99%,383,2,0.52%
-Prešov,Prešovský,Prešov,Abranovce,708,7,0.99%,561,3,0.53%
-Topoľčany,Nitriansky,Topoľčany,Koniarovce,607,6,0.99%,1343,9,0.67%
-Topoľčany,Trenčiansky,Partizánske,Ostratice,607,6,0.99%,589,3,0.51%
-Michalovce,Prešovský,Vranov nad Topľou,Hencovce,912,9,0.99%,878,7,0.80%
-Rožňava,Košický,Rimavská Sobota,Čierny Potok,304,3,0.99%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Dolinka,304,3,0.99%,,,
-Michalovce,Prešovský,Vranov nad Topľou,Hanušovce nad Topľou,1826,18,0.99%,1844,15,0.81%
-Topoľčany,Trenčiansky,Prievidza,Malá Lehôtka,509,5,0.98%,335,5,1.49%
-Prešov,Prešovský,Bardejov,Lukavica,409,4,0.98%,361,3,0.83%
-Michalovce,Prešovský,Humenné,Lieskovec,307,3,0.98%,309,0,0.00%
-Zvolen,Banskobystrický,Banská Bystrica,Dúbravica,410,4,0.98%,337,2,0.59%
-Zvolen,Banskobystrický,Žarnovica,Ostrý Grúň,410,4,0.98%,,,
-Michalovce,Prešovský,Humenné,Chlmec,513,5,0.97%,524,1,0.19%
-Nitra,Nitriansky,Nitra,Kolíňany,1026,10,0.97%,,,
-Topoľčany,Trenčiansky,Partizánske,Klížske Hradište. Veľký Klíž,616,6,0.97%,694,4,0.58%
-Rožňava,Košický,Rimavská Sobota,Večelkov,308,3,0.97%,,,
-Rožňava,Košický,Poltár,Sušany,308,3,0.97%,,,
-Malacky,Trnavský,Skalica,Radošovce,1336,13,0.97%,1311,8,0.61%
-Michalovce,Košický,Michalovce,Bánovce nad Ondavou,515,5,0.97%,601,5,0.83%
-Rožňava,Košický,Gelnica,Henclová,103,1,0.97%,125,1,0.80%
-Martin,Žilinský,Dolný Kubín,Jasenová,412,4,0.97%,348,0,0.00%
-Sereď,Bratislavský,Senec,Hurbanova Ves,413,4,0.97%,,,
-Sereď,Trnavský,Dunajská Streda,Baloň,620,6,0.97%,659,2,0.30%
-Michalovce,Košický,Michalovce,Trhovište,827,8,0.97%,987,7,0.71%
-Žilina,Žilinský,Bytča,Štiavnik,2793,27,0.97%,2743,12,0.44%
-Levice,Nitrianský,Levice,Kalná nad Hronom,1449,14,0.97%,,,
-Trenčín,Trenčiansky,Trenčín,Trenčianske Jastrabie,831,8,0.96%,876,4,0.46%
-Michalovce,Košický,Michalovce,Petrovce nad Laborcom,831,8,0.96%,743,0,0.00%
-Prešov,Prešovský,Levoča,Pavľany,208,2,0.96%,154,0,0.00%
-Trenčín,Trenčiansky,Trenčín,Horné Srnie,1769,17,0.96%,1746,12,0.69%
-Trebišov,Košický,Košice - okolie,Ďurďošík,521,5,0.96%,,,
-Michalovce,Prešovský,Vranov nad Topľou,Tovarné,730,7,0.96%,755,6,0.79%
-Trenčín,Trenčiansky,Trenčín,Dubodiel,730,7,0.96%,731,4,0.55%
-Zvolen,Banskobystrický,Zvolen,Zvolen,20889,200,0.96%,27031,80,0.30%
-Žilina,Žilinský,Žilina,Divinka,836,8,0.96%,796,3,0.38%
-Levice,Nitrianský,Komárno,Hurbanovo,4600,44,0.96%,,,
-Trenčín,Trenčiansky,Trenčín,Nemšová,4293,41,0.96%,4166,28,0.67%
-Žilina,Žilinský,Bytča,Veľké Rovné,2410,23,0.95%,2534,15,0.59%
-Zvolen,Banskobystrický,Lučenec,Lovinobaňa,1049,10,0.95%,,,
-Prešov,Prešovský,Stropkov,Breznica,525,5,0.95%,521,3,0.58%
-Prešov,Prešovský,Kežmarok,Bušovce,420,4,0.95%,408,2,0.49%
-Prešov,Prešovský,Prešov,Záhradné,1052,10,0.95%,856,3,0.35%
-Trebišov,Košický,Košice - okolie,Zlatá Idka,316,3,0.95%,,,
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Krásna Ves,422,4,0.95%,388,2,0.52%
-Prešov,Prešovský,Svidník,Hunkovce,211,2,0.95%,199,1,0.50%
-Rožňava,Košický,Rimavská Sobota,Veľké Teriakovce,528,5,0.95%,,,
-Nitra,Nitriansky,Nitra,Jelšovce,845,8,0.95%,,,
-Prešov,Prešovský,Bardejov,Raslavice,1479,14,0.95%,1462,5,0.34%
-Michalovce,Prešovský,Snina,Zemplínske Hámre,634,6,0.95%,767,12,1.56%
-Michalovce,Prešovský,Vranov nad Topľou,Pavlovce,634,6,0.95%,659,7,1.06%
-Malacky,Trnavský,Senica,Moravský Svätý Ján,2008,19,0.95%,2699,15,0.56%
-Ružomberok,Žilinský,Liptovský Mikuláš,Liptovský Hrádok,4022,38,0.94%,4338,17,0.39%
-Malacky,Trnavský,Senica,Borský Svätý Jur,1166,11,0.94%,1294,2,0.15%
-Prešov,Prešovský,Svidník,Vyšná Jedľová,106,1,0.94%,135,0,0.00%
-Malacky,Trnavský,Senica,Štefanov,1382,13,0.94%,1266,4,0.32%
-Zvolen,Banskobystrický,Lučenec,Tomášovce,958,9,0.94%,,,
-Prešov,Prešovský,Prešov,Vyšná Šebastová,1066,10,0.94%,963,2,0.21%
-Michalovce,Prešovský,Snina,Kolonica,427,4,0.94%,451,2,0.44%
-Sereď,Trnavský,Dunajská Streda,Dunajská Streda,12293,115,0.94%,14013,102,0.73%
-Martin,Žilinský,Dolný Kubín,Osádka,214,2,0.93%,170,0,0.00%
-Hlohovec,Trnavský,Trnava,Dolné Lovčice,856,8,0.93%,,,
-Malacky,Trnavský,Senica,Šajdíkove Humence,858,8,0.93%,885,6,0.68%
-Malacky,Trnavský,Skalica,Chropov,429,4,0.93%,384,1,0.26%
-Malacky,Trnavský,Senica,Sekule,1719,16,0.93%,1785,5,0.28%
-Ružomberok,Žilinský,Ružomberok,Liptovský Michal,430,4,0.93%,351,1,0.28%
-Prešov,Prešovský,Levoča,Jablonov,538,5,0.93%,545,3,0.55%
-Sereď,Trnavský,Galanta,Váhovce,1399,13,0.93%,,,
-Trenčín,Trenčiansky,Považská Bystrica,Záskalie,323,3,0.93%,247,4,1.62%
-Sereď,Trnavský,Dunajská Streda,Zlaté Klasy,1942,18,0.93%,2796,10,0.36%
-Hlohovec,Trnavský,Trnava,Malženice,972,9,0.93%,,,
-Sereď,Trnavský,Galanta,Šalgočka,216,2,0.93%,,,
-Prešov,Prešovský,Sabinov,Milpoš,433,4,0.92%,444,1,0.23%
-Prešov,Prešovský,Bardejov,Frička,217,2,0.92%,204,0,0.00%
-Michalovce,Košický,Sobrance,Jasenov,434,4,0.92%,416,0,0.00%
-Rožňava,Košický,Spišská Nová Ves,Mlynky,435,4,0.92%,956,6,0.63%
-Prešov,Prešovský,Poprad,Šuňava,1090,10,0.92%,1083,6,0.55%
-Trenčín,Trenčiansky,Považská Bystrica,Dolná Mariková,984,9,0.91%,969,11,1.14%
-Nitra,Nitriansky,Nitra,Malý Lapáš,766,7,0.91%,,,
-Trenčín,Trenčiansky,Trenčín,Chocholná - Velčice,1314,12,0.91%,1243,16,1.29%
-Prešov,Prešovský,Svidník,Kobylnice,219,2,0.91%,155,1,0.65%
-Martin,Žilinský,Martin,Turčiansky Ďur,219,2,0.91%,210,1,0.48%
-Trebišov,Košický,Trebišov,Zemplín,219,2,0.91%,,,
-Rožňava,Košický,Rimavská Sobota,Nižný Skálnik,219,2,0.91%,,,
-Trebišov,Košický,Košice - okolie,Chrastné,548,5,0.91%,,,
-Malacky,Bratislavský,Pezinok,Jablonec,768,7,0.91%,,,
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Ľutov,220,2,0.91%,221,2,0.90%
-Sereď,Trnavský,Galanta,Vinohrady nad Váhom,992,9,0.91%,,,
-Trebišov,Košický,Trebišov,Čerhov,441,4,0.91%,,,
-Prešov,Prešovský,Poprad,Tatranská Javorina,331,3,0.91%,274,3,1.09%
-Hlohovec,Trnavský,Piešťany,Chtelnica,1876,17,0.91%,,,
-Michalovce,Košický,Sobrance,Lekárovce,552,5,0.91%,531,2,0.38%
-Rožňava,Košický,Spišská Nová Ves,Vojkovce,221,2,0.90%,219,2,0.91%
-Sereď,Trnavský,Dunajská Streda,Boheľov,221,2,0.90%,251,1,0.40%
-Hlohovec,Trnavský,Piešťany,Dubovany,885,8,0.90%,,,
-Martin,Žilinský,Dolný Kubín,Sedliacka Dubová,443,4,0.90%,396,3,0.76%
-Hlohovec,Trnavský,Piešťany,Pečeňady,554,5,0.90%,,,
-Michalovce,Košický,Michalovce,Jovsa,665,6,0.90%,656,1,0.15%
-Rožňava,Košický,Spišská Nová Ves,Krompachy,4324,39,0.90%,4165,15,0.36%
-Trenčín,Trenčiansky,Myjava,Chvojnica,222,2,0.90%,240,2,0.83%
-Trebišov,Košický,Trebišov,Boťany,779,7,0.90%,,,
-Trebišov,Košický,Trebišov,Michaľany,1003,9,0.90%,,,
-Prešov,Prešovský,Levoča,Dúbrava,223,2,0.90%,218,0,0.00%
-Prešov,Prešovský,Kežmarok,Lechnica,223,2,0.90%,221,0,0.00%
-Levice,Nitrianský,Levice,Podlužany,446,4,0.90%,,,
-Hlohovec,Trnavský,Trnava,Borová,335,3,0.90%,,,
-Nitra,Nitriansky,Nitra,Podhorany,782,7,0.90%,,,
-Trebišov,Košický,Trebišov,Veľké Ozorovce,447,4,0.89%,,,
-Ružomberok,Žilinský,Ružomberok,Hubová,671,6,0.89%,659,7,1.06%
-Michalovce,Prešovský,Humenné,Zbudské Dlhé,560,5,0.89%,484,9,1.86%
-Prešov,Prešovský,Svidník,Nižný Orlík,112,1,0.89%,114,0,0.00%
-Prešov,Prešovský,Prešov,Suchá Dolina,112,1,0.89%,113,0,0.00%
-Rožňava,Košický,Poltár,Šoltýska,112,1,0.89%,,,
-Žilina,Žilinský,Žilina,Rajec,3484,31,0.89%,3703,28,0.76%
-Hlohovec,Trnavský,Trnava,Zavar,1574,14,0.89%,,,
-Sereď,Trnavský,Galanta,Pusté Úľany,1013,9,0.89%,,,
-Prešov,Prešovský,Prešov,Ličartovce,677,6,0.89%,1150,3,0.26%
-Levice,Nitrianský,Komárno,Pribeta,1811,16,0.88%,,,
-Levice,Nitrianský,Levice,Horné Túrovce,453,4,0.88%,,,
-Sereď,Trnavský,Dunajská Streda,Janíky,793,7,0.88%,1290,5,0.39%
-Martin,Žilinský,Turčianske Teplice,Turčianske Teplice,3173,28,0.88%,3622,18,0.50%
-Ružomberok,Žilinský,Liptovský Mikuláš,Veterná Poruba,227,2,0.88%,225,3,1.33%
-Martin,Žilinský,Martin,Vrícko,454,4,0.88%,369,1,0.27%
-Zvolen,Banskobystrický,Brezno,Vaľkovňa,341,3,0.88%,349,5,1.43%
-Prešov,Prešovský,Prešov,Drienov,1365,12,0.88%,2299,13,0.57%
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Horná Streda,910,8,0.88%,2144,10,0.47%
-Michalovce,Prešovský,Vranov nad Topľou,Skrabské,455,4,0.88%,473,0,0.00%
-Hlohovec,Trnavský,Trnava,Pavlice,569,5,0.88%,,,
-Zvolen,Banskobystrický,Žiar nad Hronom,Pitelová,572,5,0.87%,,,
-Zvolen,Banskobystrický,Krupina,Dudince,801,7,0.87%,,,
-Ružomberok,Žilinský,Liptovský Mikuláš,Gôtovany,458,4,0.87%,428,4,0.93%
-Prešov,Prešovský,Prešov,Podhradík,229,2,0.87%,234,0,0.00%
-Žilina,Žilinský,Žilina,Terchová,2749,24,0.87%,3031,7,0.23%
-Levice,Nitrianský,Komárno,Iža,1146,10,0.87%,,,
-Hlohovec,Trnavský,Trnava,Biely Kostol,1721,15,0.87%,,,
-Levice,Nitrianský,Levice,Keť,459,4,0.87%,,,
-Žilina,Žilinský,Žilina,Lietava,1149,10,0.87%,1026,1,0.10%
-Bratislava,Bratislavský,Bratislava II,Bratislava - Vrakuňa,12759,111,0.87%,,,
-Prešov,Prešovský,Bardejov,Snakov,460,4,0.87%,464,0,0.00%
-Martin,Žilinský,Dolný Kubín,Krivá,576,5,0.87%,584,2,0.34%
-Rožňava,Košický,Gelnica,Mníšek nad Hnilcom,923,8,0.87%,866,1,0.12%
-Prešov,Prešovský,Prešov,Medzany,693,6,0.87%,751,4,0.53%
-Michalovce,Košický,Sobrance,Krčava,578,5,0.87%,562,2,0.36%
-Martin,Žilinský,Turčianske Teplice,Jazernica,348,3,0.86%,347,4,1.15%
-Nitra,Nitriansky,Nitra,Ľudovítová,116,1,0.86%,,,
-Michalovce,Košický,Michalovce,Hažín,465,4,0.86%,388,1,0.26%
-Prešov,Prešovský,Prešov,Fintice,1279,11,0.86%,1441,7,0.49%
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Nové Mesto nad Váhom,10935,94,0.86%,11819,27,0.23%
-Martin,Žilinský,Martin,Benice,466,4,0.86%,349,3,0.86%
-Žilina,Žilinský,Žilina,Kunerad,816,7,0.86%,804,3,0.37%
-Zvolen,Banskobystrický,Banská Bystrica,Harmanec,700,6,0.86%,638,3,0.47%
-Trebišov,Košický,Košice - okolie,Cestice,700,6,0.86%,,,
-Trebišov,Košický,Košice - okolie,Žarnov,235,2,0.85%,,,
-Sereď,Bratislavský,Senec,Boldog,471,4,0.85%,,,
-Martin,Žilinský,Turčianske Teplice,Jasenovo,236,2,0.85%,388,0,0.00%
-Žilina,Žilinský,Žilina,Rajecká Lesná,827,7,0.85%,863,10,1.16%
-Rožňava,Košický,Gelnica,Margecany,1301,11,0.85%,1430,4,0.28%
-Levice,Nitriansky,Nové Zámky,Strekov,1184,10,0.84%,,,
-Sereď,Trnavský,Galanta,Čierna Voda,948,8,0.84%,,,
-Zvolen,Banskobystrický,Krupina,Hontianske Nemce,830,7,0.84%,,,
-Prešov,Prešovský,Poprad,Nová Lesná,1068,9,0.84%,1090,3,0.28%
-Zvolen,Banskobystrický,Banská Bystrica,Kynceľová,476,4,0.84%,474,1,0.21%
-Prešov,Prešovský,Stropkov,Breznička,119,1,0.84%,113,0,0.00%
-Prešov,Prešovský,Bardejov,Šašová,119,1,0.84%,114,0,0.00%
-Michalovce,Prešovský,Vranov nad Topľou,Banské,1072,9,0.84%,1016,6,0.59%
-Levice,Nitrianský,Komárno,Tôň,715,6,0.84%,,,
-Prešov,Prešovský,Prešov,Dulova Ves,1073,9,0.84%,1046,6,0.57%
-Trenčín,Trenčiansky,Považská Bystrica,Počarová,358,3,0.84%,255,1,0.39%
-Sereď,Trnavský,Dunajská Streda,Orechová Potôň,1671,14,0.84%,1608,4,0.25%
-Trebišov,Košický,Košice II,Košice - Poľov,597,5,0.84%,,,
-Nitra,Nitriansky,Zlaté Moravce,Kostoľany pod Tribečom,240,2,0.83%,,,
-Prešov,Prešovský,Prešov,Chminianska Nová Ves,721,6,0.83%,746,2,0.27%
-Trebišov,Košický,Trebišov,Veľký Horeš,601,5,0.83%,,,
-Sereď,Bratislavský,Senec,Kostolná pri Dunaj,1087,9,0.83%,,,
-Levice,Nitriansky,Nové Zámky,Salka,604,5,0.83%,,,
-Hlohovec,Trnavský,Trnava,Ružindol,1089,9,0.83%,,,
-Zvolen,Banskobystrický,Lučenec,Točnica,363,3,0.83%,,,
-Prešov,Prešovský,Prešov,Veľký Šariš,4242,35,0.83%,4256,13,0.31%
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Modrová,485,4,0.82%,471,0,0.00%
-Martin,Žilinský,Turčianske Teplice,Bodorová,243,2,0.82%,240,0,0.00%
-Levice,Nitrianský,Levice,Ipeľské Úľany,243,2,0.82%,,,
-Trenčín,Trenčiansky,Trenčín,Ivanovce,608,5,0.82%,614,1,0.16%
-Trebišov,Košický,Košice - okolie,Vtáčkovce,608,5,0.82%,,,
-Topoľčany,Nitriansky,Topoľčany,Nitrianska Blatnica,730,6,0.82%,864,7,0.81%
-Hlohovec,Trnavský,Piešťany,Sokolovce,852,7,0.82%,,,
-Michalovce,Prešovský,Medzilaborce,Výrava,366,3,0.82%,361,3,0.83%
-Prešov,Prešovský,Bardejov,Porúbka,244,2,0.82%,215,0,0.00%
-Hlohovec,Trnavský,Hlohovec,Madunice,1710,14,0.82%,,,
-Levice,Nitrianský,Levice,Šahy,3543,29,0.82%,,,
-Michalovce,Košický,Michalovce,Zemplínska Široká,611,5,0.82%,599,0,0.00%
-Michalovce,Košický,Sobrance,Sobrance,2691,22,0.82%,2742,9,0.33%
-Trenčín,Trenčiansky,Trenčín,Drietoma,1468,12,0.82%,1542,16,1.04%
-Nitra,Nitriansky,Šaľa,Tešedíkovo,2449,20,0.82%,,,
-Michalovce,Košický,Michalovce,Zbudza,491,4,0.81%,451,0,0.00%
-Levice,Nitrianský,Komárno,Komárno,18244,148,0.81%,,,
-Rožňava,Košický,Rimavská Sobota,Klenovec,1727,14,0.81%,,,
-Hlohovec,Trnavský,Hlohovec,Koplotovce,988,8,0.81%,,,
-Trebišov,Košický,Košice - okolie,Vyšná Myšľa,741,6,0.81%,,,
-Žilina,Žilinský,Žilina,Dolný Hričov,1116,9,0.81%,996,2,0.20%
-Trebišov,Košický,Košice - okolie,Košická Polianka,745,6,0.81%,,,
-Ružomberok,Žilinský,Liptovský Mikuláš,Partizánska Ľupča,871,7,0.80%,1057,7,0.66%
-Ružomberok,Žilinský,Liptovský Mikuláš,Východná,1369,11,0.80%,1375,13,0.95%
-Levice,Nitriansky,Nové Zámky,Jatov,498,4,0.80%,,,
-Rožňava,Košický,Rimavská Sobota,Husiná,249,2,0.80%,,,
-Zvolen,Banskobystrický,Banská Bystrica,Kordíky,623,5,0.80%,536,1,0.19%
-Trebišov,Košický,Košice - okolie,Vyšná Kamenica,374,3,0.80%,,,
-Levice,Nitrianský,Komárno,Modrany. Mudroňovo,873,7,0.80%,,,
-Michalovce,Prešovský,Vranov nad Topľou,Bystré,1500,12,0.80%,1498,3,0.20%
-Žilina,Žilinský,Žilina,Višňové,1881,15,0.80%,1982,8,0.40%
-Žilina,Žilinský,Žilina,Strečno,1883,15,0.80%,1849,8,0.43%
-Michalovce,Prešovský,Humenné,Hudcovce,377,3,0.80%,270,2,0.74%
-Nitra,Nitriansky,Nitra,Branč,1508,12,0.80%,,,
-Trebišov,Košický,Trebišov,Zatín,377,3,0.80%,,,
-Sereď,Trnavský,Dunajská Streda,Horná Potôň,1766,14,0.79%,1842,8,0.43%
-Žilina,Žilinský,Bytča,Hvozdnica,757,6,0.79%,775,4,0.52%
-Michalovce,Prešovský,Vranov nad Topľou,Soľ,1516,12,0.79%,1491,1,0.07%
-Hlohovec,Trnavský,Trnava,Vlčkovce,1137,9,0.79%,,,
-Martin,Žilinský,Dolný Kubín,Bziny,380,3,0.79%,386,4,1.04%
-Prešov,Prešovský,Prešov,Janovík,380,3,0.79%,1138,6,0.53%
-Prešov,Prešovský,Bardejov,Richvald,635,5,0.79%,629,5,0.79%
-Rožňava,Košický,Gelnica,Gelnica,3180,25,0.79%,3484,13,0.37%
-Trenčín,Trenčiansky,Myjava,Brezová pod Bradlom,2928,23,0.79%,3252,6,0.18%
-Zvolen,Banskobystrický,Veľký Krtíš,Lesenice + Trebušovce,510,4,0.78%,,,
-Sereď,Trnavský,Dunajská Streda,Veľké Dvorníky,893,7,0.78%,1159,4,0.35%
-Trebišov,Košický,Košice - okolie,Nižná Hutka,639,5,0.78%,,,
-Trebišov,Košický,Košice - okolie,Zádiel,128,1,0.78%,,,
-Rožňava,Košický,Poltár,Poltár,3201,25,0.78%,,,
-Michalovce,Prešovský,Vranov nad Topľou,Sedliská,769,6,0.78%,768,3,0.39%
-Zvolen,Banskobystrický,Banská Bystrica,Tajov,641,5,0.78%,763,5,0.66%
-Nitra,Nitriansky,Nitra,Nitrianske,1669,13,0.78%,,,
-Trebišov,Košický,Košice I,Košice - Ťahanovce,1669,13,0.78%,,,
-Ružomberok,Žilinský,Liptovský Mikuláš,Liptovská Kokava,642,5,0.78%,675,9,1.33%
-Rožňava,Košický,Spišská Nová Ves,Rudňany,2440,19,0.78%,2186,3,0.14%
-Nitra,Nitriansky,Šaľa,Kráľová nad Váhom,1028,8,0.78%,,,
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Očkov,515,4,0.78%,1222,13,1.06%
-Nitra,Nitriansky,Nitra,Lužianky,1288,10,0.78%,,,
-Prešov,Prešovský,Prešov,Žipov,258,2,0.78%,256,9,3.52%
-Prešov,Prešovský,Prešov,Šarišské Bohdanovce,645,5,0.78%,1584,4,0.25%
-Prešov,Prešovský,Prešov,Mirkovce,645,5,0.78%,714,0,0.00%
-Trebišov,Košický,Košice II,Košice - Luník IX,1292,10,0.77%,,,
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Beckov,1034,8,0.77%,1127,2,0.18%
-Trebišov,Košický,Košice - okolie,Sokoľ,907,7,0.77%,,,
-Levice,Nitrianský,Levice,Nová Dedina,778,6,0.77%,,,
-Rožňava,Košický,Spišská Nová Ves,Bystrany,1038,8,0.77%,946,7,0.74%
-Levice,Nitrianský,Levice,Žemberovce. Brhlovce,1168,9,0.77%,,,
-Martin,Žilinský,Dolný Kubín,Oravská  Poruba,650,5,0.77%,727,0,0.00%
-Rožňava,Košický,Rimavská Sobota,Nová Bašta,260,2,0.77%,,,
-Zvolen,Banskobystrický,Banská Bystrica,Slovenská Ľupča,2083,16,0.77%,2200,20,0.91%
-Žilina,Žilinský,Žilina,Ovčiarsko,391,3,0.77%,406,3,0.74%
-Michalovce,Košický,Michalovce,Voľa,391,3,0.77%,378,0,0.00%
-Zvolen,Banskobystrický,Lučenec,Buzitka,522,4,0.77%,,,
-Prešov,Prešovský,Poprad,Gánovce,914,7,0.77%,891,3,0.34%
-Malacky,Bratislavský,Malacky,Malacky,9929,76,0.77%,,,
-Trebišov,Košický,Trebišov,Čierna nad Tisou,1963,15,0.76%,,,
-Trenčín,Trenčiansky,Ilava,Bolešov,1178,9,0.76%,1063,9,0.85%
-Trebišov,Košický,Trebišov,Novosad,525,4,0.76%,,,
-Michalovce,Prešovský,Vranov nad Topľou,Malá Domaša,394,3,0.76%,377,1,0.27%
-Zvolen,Banskobystrický,Banská Bystrica,Hiadeľ,395,3,0.76%,385,3,0.78%
-Trenčín,Trenčiansky,Myjava,Myjava,6995,53,0.76%,7292,35,0.48%
-Zvolen,Banskobystrický,Detva,Dúbravy,924,7,0.76%,778,5,0.64%
-Rožňava,Košický,Spišská Nová Ves,Poráč,660,5,0.76%,626,3,0.48%
-Nitra,Nitriansky,Šaľa,Hájske,793,6,0.76%,,,
-Trenčín,Trenčiansky,Trenčín,Melčice - Lieskové,1325,10,0.75%,1166,0,0.00%
-Trenčín,Trenčiansky,Trenčín,Petrova Lehota,133,1,0.75%,114,0,0.00%
-Trebišov,Košický,Košice - okolie,Hosťovce,266,2,0.75%,,,
-Sereď,Trnavský,Dunajská Streda,Dolný Bar,799,6,0.75%,873,3,0.34%
-Levice,Nitrianský,Levice,Veľké Ludince,799,6,0.75%,,,
-Prešov,Prešovský,Stará Ľubovňa,Vyšné Ružbachy,666,5,0.75%,643,4,0.62%
-Hlohovec,Trnavský,Trnava,Dolná Krupá,1865,14,0.75%,,,
-Rožňava,Košický,Gelnica,Veľký Folkmar,667,5,0.75%,801,1,0.12%
-Michalovce,Prešovský,Vranov nad Topľou,Kladzany,401,3,0.75%,457,1,0.22%
-Nitra,Nitriansky,Šaľa,Horná Kráľová,1206,9,0.75%,,,
-Levice,Nitriansky,Nové Zámky,Malé Kosihy,268,2,0.75%,,,
-Malacky,Bratislavský,Malacky,Stupava,8042,60,0.75%,,,
-Rožňava,Košický,Rožňava,Rožňavské Bystré,403,3,0.74%,,,
-Trenčín,Trenčiansky,Trenčín,Skalka nad Váhom,944,7,0.74%,749,2,0.27%
-Prešov,Prešovský,Stropkov,Tisinec,270,2,0.74%,308,3,0.97%
-Prešov,Prešovský,Bardejov,Stuľany,405,3,0.74%,416,4,0.96%
-Trenčín,Trenčiansky,Trenčín,Veľké Bierovce,540,4,0.74%,501,1,0.20%
-Prešov,Prešovský,Stropkov,Bžany,135,1,0.74%,164,0,0.00%
-Prešov,Prešovský,Prešov,Lipníky,406,3,0.74%,428,1,0.23%
-Zvolen,Banskobystrický,Lučenec,Stará Halič,406,3,0.74%,,,
-Prešov,Prešovský,Bardejov,Dubinné,271,2,0.74%,268,1,0.37%
-Michalovce,Košický,Sobrance,Kristy,271,2,0.74%,271,1,0.37%
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Nová Lehota,271,2,0.74%,359,1,0.28%
-Trenčín,Trenčiansky,Ilava,Pruské,1631,12,0.74%,1613,9,0.56%
-Prešov,Prešovský,Prešov,Lúčina,136,1,0.74%,127,0,0.00%
-Trebišov,Košický,Trebišov,Kravany,272,2,0.74%,,,
-Malacky,Trnavský,Senica,Plavecký Peter,546,4,0.73%,921,3,0.33%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Timoradza,273,2,0.73%,278,0,0.00%
-Levice,Nitrianský,Komárno,Dulovce,957,7,0.73%,,,
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Nová Bošáca,821,6,0.73%,816,0,0.00%
-Hlohovec,Trnavský,Trnava,Opoj,823,6,0.73%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Ipeľské Predmostie,412,3,0.73%,,,
-Zvolen,Banskobystrický,Žiar nad Hronom,Repište,275,2,0.73%,,,
-Ružomberok,Žilinský,Liptovský Mikuláš,Bobrovec,1376,10,0.73%,1388,11,0.79%
-Levice,Nitriansky,Nové Zámky,Nána,826,6,0.73%,,,
-Zvolen,Banskobystrický,Zvolen,Sása,689,5,0.73%,801,2,0.25%
-Zvolen,Banskobystrický,Lučenec,Trebeľovce,689,5,0.73%,,,
-Topoľčany,Nitriansky,Topoľčany,Malé Ripňany,690,5,0.72%,1037,11,1.06%
-Prešov,Prešovský,Stará Ľubovňa,Legnava,138,1,0.72%,107,1,0.93%
-Nitra,Nitriansky,Nitra,Šurianky,690,5,0.72%,,,
-Zvolen,Banskobystrický,Lučenec,Kalonda,138,1,0.72%,,,
-Levice,Nitrianský,Komárno,Okoličná na Ostrove,968,7,0.72%,,,
-Prešov,Prešovský,Bardejov,Lascov,277,2,0.72%,233,1,0.43%
-Sereď,Trnavský,Dunajská Streda,Kráľovičove Kračany,1109,8,0.72%,1173,11,0.94%
-Michalovce,Prešovský,Snina,Dúbrava,278,2,0.72%,273,5,1.83%
-Prešov,Prešovský,Bardejov,Kučín,139,1,0.72%,157,0,0.00%
-Levice,Nitrianský,Levice,Drženice,417,3,0.72%,,,
-Nitra,Nitriansky,Nitra,Nová Ves nad Žitavou,834,6,0.72%,,,
-Trenčín,Trenčiansky,Myjava,Kostolné,697,5,0.72%,672,0,0.00%
-Žilina,Žilinský,Žilina,Hôrky,838,6,0.72%,716,2,0.28%
-Topoľčany,Nitriansky,Topoľčany,Šalgovce,559,4,0.72%,884,8,0.90%
-Zvolen,Banskobystrický,Veľký Krtíš,Opatovská Nová Ves + Slovenské Ďarmoty,699,5,0.72%,,,
-Martin,Žilinský,Námestovo,Breza,840,6,0.71%,1022,3,0.29%
-Martin,Žilinský,Turčianske Teplice,Kaľamenová,140,1,0.71%,129,0,0.00%
-Rožňava,Košický,Rimavská Sobota,Lehota nad Rimavicou,140,1,0.71%,,,
-Hlohovec,Trnavský,Hlohovec,Kľačany,701,5,0.71%,,,
-Nitra,Nitriansky,Zlaté Moravce,Machulince,701,5,0.71%,,,
-Michalovce,Košický,Sobrance,Záhor,421,3,0.71%,442,0,0.00%
-Zvolen,Banskobystrický,Žiar nad Hronom,Ladomerská Vieska,702,5,0.71%,,,
-Michalovce,Košický,Michalovce,Kačanov,281,2,0.71%,297,0,0.00%
-Prešov,Prešovský,Stropkov,Veľkrop,141,1,0.71%,147,1,0.68%
-Hlohovec,Trnavský,Piešťany,Trebatice,988,7,0.71%,,,
-Prešov,Prešovský,Prešov,Župčany,1273,9,0.71%,1211,5,0.41%
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Dolné Srnie,708,5,0.71%,714,5,0.70%
-Trebišov,Košický,Košice - okolie,Boliarov,567,4,0.71%,,,
-Rožňava,Košický,Rimavská Sobota,Hnúšťa,3409,24,0.70%,,,
-Levice,Nitriansky,Nové Zámky,Kolta,853,6,0.70%,,,
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Zemianske Podhradie,711,5,0.70%,711,3,0.42%
-Prešov,Prešovský,Prešov,Petrovany,1140,8,0.70%,1171,5,0.43%
-Zvolen,Banskobystrický,Detva,Klokoč,285,2,0.70%,300,1,0.33%
-Levice,Nitriansky,Nové Zámky,Mužla,1425,10,0.70%,,,
-Trebišov,Košický,Trebišov,Ladmovce,286,2,0.70%,,,
-Trebišov,Košický,Košice - okolie,Moldava nad Bodvou,4719,33,0.70%,,,
-Levice,Nitriansky,Nové Zámky,Dedinka,574,4,0.70%,,,
-Nitra,Nitriansky,Zlaté Moravce,Žikava,431,3,0.70%,,,
-Sereď,Bratislavský,Senec,Kaplna,863,6,0.70%,,,
-Levice,Nitriansky,Nové Zámky,Dolný Ohaj,1158,8,0.69%,,,
-Trenčín,Trenčiansky,Myjava,Košariská,436,3,0.69%,496,2,0.40%
-Michalovce,Prešovský,Humenné,Rokytov pri Humennom,291,2,0.69%,301,0,0.00%
-Prešov,Prešovský,Levoča,Buglovce,146,1,0.68%,140,1,0.71%
-Zvolen,Banskobystrický,Zvolen,Ostrá Lúka. Bacúrov. Breziny,438,3,0.68%,478,0,0.00%
-Zvolen,Banskobystrický,Zvolen,Sliač,3213,22,0.68%,3978,7,0.18%
-Nitra,Nitriansky,Nitra,Svätoplukovo,1024,7,0.68%,,,
-Rožňava,Košický,Gelnica,Kojšov,294,2,0.68%,547,3,0.55%
-Nitra,Nitriansky,Nitra,Veľké Chyndice,147,1,0.68%,,,
-Nitra,Nitriansky,Zlaté Moravce,Neverice,740,5,0.68%,,,
-Ružomberok,Žilinský,Tvrdošín,Podbiel,889,6,0.67%,828,6,0.72%
-Hlohovec,Trnavský,Hlohovec,Siladice,593,4,0.67%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Kosihovce + Opava,447,3,0.67%,,,
-Nitra,Nitriansky,Nitra,Veľká Dolina,597,4,0.67%,,,
-Michalovce,Košický,Michalovce,Michalovce,16275,109,0.67%,17919,42,0.23%
-Zvolen,Banskobystrický,Lučenec,Lučenec,12445,83,0.67%,,,
-Trebišov,Košický,Košice - okolie,Trstené pri Hornáde,900,6,0.67%,,,
-Topoľčany,Nitriansky,Topoľčany,Radošina,1206,8,0.66%,1710,7,0.41%
-Sereď,Trnavský,Dunajská Streda,Mad,302,2,0.66%,281,2,0.71%
-Prešov,Prešovský,Prešov,Kvačany,151,1,0.66%,227,0,0.00%
-Malacky,Trnavský,Senica,Čáry,909,6,0.66%,994,1,0.10%
-Trebišov,Košický,Trebišov,Sečovce,3486,23,0.66%,,,
-Levice,Nitrianský,Levice,Dolná Seč. Vyšné nad Hronom,456,3,0.66%,,,
-Trebišov,Košický,Košice - okolie,Debraď,304,2,0.66%,,,
-Trebišov,Košický,Košice - okolie,Nová Polhora,304,2,0.66%,,,
-Zvolen,Banskobystrický,Lučenec,Boľkovce,304,2,0.66%,,,
-Levice,Nitriansky,Nové Zámky,Kamenný Most,913,6,0.66%,,,
-Levice,Nitriansky,Nové Zámky,Kamenín,762,5,0.66%,,,
-Trebišov,Košický,Trebišov,Kazimír,610,4,0.66%,,,
-Levice,Nitrianský,Levice,Lok,458,3,0.66%,,,
-Trenčín,Trenčiansky,Trenčín,Trenčianske Stankovce,2293,15,0.65%,2341,11,0.47%
-Malacky,Bratislavský,Pezinok,Pezinok,15296,100,0.65%,,,
-Prešov,Prešovský,Bardejov,Oľšavce,153,1,0.65%,148,0,0.00%
-Rožňava,Košický,Rimavská Sobota,Hrachovo,612,4,0.65%,,,
-Rožňava,Košický,Rimavská Sobota,Vyšný Skálnik,153,1,0.65%,,,
-Rožňava,Košický,Revúca,Levkuška,153,1,0.65%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Dolná Strehová + Ľuboriečka,918,6,0.65%,,,
-Sereď,Trnavský,Galanta,Šoporňa,2605,17,0.65%,,,
-Zvolen,Banskobystrický,Banská Bystrica,Špania Dolina,613,4,0.65%,444,0,0.00%
-Rožňava,Košický,Spišská Nová Ves,Spišský Hrušov,923,6,0.65%,930,7,0.75%
-Prešov,Prešovský,Poprad,Švábovce,923,6,0.65%,937,6,0.64%
-Michalovce,Prešovský,Vranov nad Topľou,Hlinné,1236,8,0.65%,1233,15,1.22%
-Rožňava,Košický,Rimavská Sobota,Abovce,464,3,0.65%,,,
-Trebišov,Košický,Trebišov,Malý Kamenec,310,2,0.65%,,,
-Malacky,Bratislavský,Pezinok,Svätý Jur,4032,26,0.64%,,,
-Sereď,Trnavský,Dunajská Streda,Dunajský Klátov,776,5,0.64%,1354,4,0.30%
-Hlohovec,Trnavský,Piešťany,Ratnovce,777,5,0.64%,,,
-Zvolen,Banskobystrický,Žarnovica,Župkov,622,4,0.64%,,,
-Martin,Žilinský,Martin,Krpeľany,623,4,0.64%,589,6,1.02%
-Hlohovec,Trnavský,Trnava,Hrnčiarovce nad Parnou,1558,10,0.64%,,,
-Sereď,Bratislavský,Senec,Nový Svet,156,1,0.64%,,,
-Malacky,Bratislavský,Pezinok,Píla,469,3,0.64%,,,
-Sereď,Trnavský,Galanta,Tomášikovo,1252,8,0.64%,,,
-Sereď,Trnavský,Dunajská Streda,Báč,783,5,0.64%,671,3,0.45%
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Podolie,1098,7,0.64%,1424,5,0.35%
-Topoľčany,Nitriansky,Topoľčany,Rajčany,472,3,0.64%,454,7,1.54%
-Levice,Nitrianský,Levice,Uhliská,315,2,0.63%,,,
-Nitra,Nitriansky,Zlaté Moravce,Slepčany,630,4,0.63%,,,
-Zvolen,Banskobystrický,Brezno,Dolná Lehota,788,5,0.63%,707,8,1.13%
-Trebišov,Košický,Košice I,Košice - Džungľa,946,6,0.63%,,,
-Sereď,Trnavský,Dunajská Streda,Lúč na Ostrove,1105,7,0.63%,709,2,0.28%
-Malacky,Bratislavský,Malacky,Studienka,1105,7,0.63%,,,
-Trebišov,Košický,Košice I,Košice - Staré Mesto,11366,72,0.63%,,,
-Zvolen,Banskobystrický,Krupina,Rykynčice,316,2,0.63%,,,
-Hlohovec,Trnavský,Trnava,Trnava,35474,224,0.63%,,,
-Trebišov,Košický,Košice - okolie,Haniska,952,6,0.63%,,,
-Zvolen,Banskobystrický,Banská Štiavnica,Štiavnické Bane,635,4,0.63%,,,
-Martin,Žilinský,Dolný Kubín,Pucov,477,3,0.63%,520,1,0.19%
-Prešov,Prešovský,Sabinov,Tichý Potok,159,1,0.63%,179,0,0.00%
-Zvolen,Banskobystrický,Zvolen,Lukavica,159,1,0.63%,176,0,0.00%
-Zvolen,Banskobystrický,Žiar nad Hronom,Lehôtka pod Brehmi,159,1,0.63%,,,
-Malacky,Bratislavský,Pezinok,Limbach,1591,10,0.63%,,,
-Levice,Nitrianský,Komárno,Nesvady,3355,21,0.63%,,,
-Martin,Žilinský,Dolný Kubín,Leštiny,320,2,0.63%,327,3,0.92%
-Levice,Nitrianský,Levice,Zbrojníky,640,4,0.63%,,,
-Prešov,Prešovský,Kežmarok,Ihľany,961,6,0.62%,985,6,0.61%
-Michalovce,Prešovský,Medzilaborce,Habura,482,3,0.62%,564,2,0.35%
-Ružomberok,Žilinský,Liptovský Mikuláš,Podtureň,645,4,0.62%,668,3,0.45%
-Levice,Nitriansky,Nové Zámky,Radava,647,4,0.62%,,,
-Ružomberok,Žilinský,Liptovský Mikuláš,Liptovský Peter,809,5,0.62%,805,2,0.25%
-Malacky,Trnavský,Senica,Prievaly,810,5,0.62%,1104,3,0.27%
-Prešov,Prešovský,Levoča,Torysky,162,1,0.62%,152,0,0.00%
-Prešov,Prešovský,Bardejov,Fričkovce,487,3,0.62%,472,4,0.85%
-Malacky,Trnavský,Senica,Borský Mikuláš,2922,18,0.62%,2958,5,0.17%
-Trebišov,Košický,Trebišov,Malé Ozorovce,325,2,0.62%,,,
-Sereď,Trnavský,Dunajská Streda,Štvrtok na Ostrove,1139,7,0.61%,1689,5,0.30%
-Trebišov,Košický,Košice - okolie,Sokoľany,814,5,0.61%,,,
-Sereď,Trnavský,Dunajská Streda,Veľké Blahovo,977,6,0.61%,1066,5,0.47%
-Martin,Žilinský,Martin,Ďanová,489,3,0.61%,421,1,0.24%
-Trebišov,Košický,Trebišov,Leles,489,3,0.61%,,,
-Trebišov,Košický,Trebišov,Trebišov,1306,8,0.61%,,,
-Trenčín,Trenčiansky,Trenčín,Dolná Poruba,654,4,0.61%,569,7,1.23%
-Zvolen,Banskobystrický,Žiar nad Hronom,Dolná Trnávka,655,4,0.61%,,,
-Sereď,Bratislavský,Senec,Bernolákovo,5410,33,0.61%,,,
-Zvolen,Banskobystrický,Brezno,Mýto pod Ďumbierom,492,3,0.61%,495,0,0.00%
-Trebišov,Košický,Trebišov,Boľ,492,3,0.61%,,,
-Rožňava,Košický,Rožňava,Kováčová,164,1,0.61%,,,
-Malacky,Bratislavský,Malacky,Sološnica,1313,8,0.61%,,,
-Žilina,Žilinský,Žilina,Ďurčiná,821,5,0.61%,772,4,0.52%
-Sereď,Bratislavský,Senec,Hrubá Borša,1316,8,0.61%,,,
-Nitra,Nitriansky,Nitra,Výčapy,1481,9,0.61%,,,
-Zvolen,Banskobystrický,Brezno,Michalová,825,5,0.61%,864,6,0.69%
-Trenčín,Trenčiansky,Ilava,Vršatské Podhradie,165,1,0.61%,156,1,0.64%
-Hlohovec,Trnavský,Hlohovec,Dolné Trhovište,495,3,0.61%,,,
-Levice,Nitrianský,Levice,Tlmače,2148,13,0.61%,,,
-Trebišov,Košický,Trebišov,Kuzmice,994,6,0.60%,,,
-Prešov,Prešovský,Prešov,Miklušovce,166,1,0.60%,183,1,0.55%
-Martin,Žilinský,Martin,Necpaly,498,3,0.60%,577,3,0.52%
-Sereď,Trnavský,Dunajská Streda,Blatná na Ostrove,830,5,0.60%,982,5,0.51%
-Prešov,Prešovský,Prešov,Tuhrina,332,2,0.60%,377,0,0.00%
-Trebišov,Košický,Trebišov,Somotor,665,4,0.60%,,,
-Sereď,Trnavský,Galanta,Horné Saliby,1663,10,0.60%,,,
-Prešov,Prešovský,Svidník,Ladomirová,499,3,0.60%,417,0,0.00%
-Žilina,Žilinský,Žilina,Brezany,500,3,0.60%,473,0,0.00%
-Hlohovec,Trnavský,Hlohovec,Hlohovec,12005,72,0.60%,,,
-Rožňava,Košický,Spišská Nová Ves,Slovinky,1001,6,0.60%,1039,2,0.19%
-Prešov,Prešovský,Kežmarok,Toporec,837,5,0.60%,822,10,1.22%
-Žilina,Žilinský,Žilina,Fačkov,670,4,0.60%,684,5,0.73%
-Trebišov,Košický,Trebišov,Kysta,335,2,0.60%,,,
-Levice,Nitrianský,Komárno,Zlatná na Ostrove,1843,11,0.60%,,,
-Trebišov,Košický,Košice IV,Košice - Juh,8557,51,0.60%,,,
-Prešov,Prešovský,Svidník,Nižný Mirošov,168,1,0.60%,127,2,1.57%
-Prešov,Prešovský,Prešov,Chmiňany,840,5,0.60%,762,2,0.26%
-Nitra,Nitriansky,Šaľa,Žihárec,1010,6,0.59%,,,
-Malacky,Trnavský,Skalica,Radimov,843,5,0.59%,665,1,0.15%
-Nitra,Nitriansky,Zlaté Moravce,Skýcov,675,4,0.59%,,,
-Trebišov,Košický,Trebišov,Malé Trakany,676,4,0.59%,,,
-Michalovce,Košický,Michalovce,Strážske,2198,13,0.59%,2275,6,0.26%
-Michalovce,Prešovský,Vranov nad Topľou,Holčíkovce,509,3,0.59%,535,0,0.00%
-Levice,Nitrianský,Levice,Santovka. Bory. Domadice,850,5,0.59%,,,
-Sereď,Trnavský,Dunajská Streda,Ňárad,682,4,0.59%,641,4,0.62%
-Trebišov,Košický,Košice - okolie,Sady nad Torysou,1878,11,0.59%,,,
-Trebišov,Košický,Košice I,Košice - Sídlisko Ťahanovce,7178,42,0.59%,,,
-Topoľčany,Nitriansky,Topoľčany,Vozokany,342,2,0.58%,353,1,0.28%
-Rožňava,Košický,Gelnica,Helcmanovce,856,5,0.58%,898,0,0.00%
-Sereď,Trnavský,Dunajská Streda,Lehnice,1713,10,0.58%,2110,13,0.62%
-Nitra,Nitriansky,Nitra,Nitra,44219,258,0.58%,,,
-Sereď,Bratislavský,Senec,Blatné,1544,9,0.58%,,,
-Levice,Nitrianský,Levice,Horná Seč,688,4,0.58%,,,
-Levice,Nitrianský,Levice,Pukanec. Devičany,1206,7,0.58%,,,
-Zvolen,Banskobystrický,Banská Bystrica,Staré Hory,690,4,0.58%,750,0,0.00%
-Sereď,Trnavský,Dunajská Streda,Trstená na Ostrove,864,5,0.58%,407,4,0.98%
-Rožňava,Košický,Revúca,Leváre. Držkovce,346,2,0.58%,,,
-Trenčín,Trenčiansky,Trenčín,Kostolná - Záriečie,521,3,0.58%,494,1,0.20%
-Ružomberok,Žilinský,Liptovský Mikuláš,Kráľova Lehota,348,2,0.57%,358,3,0.84%
-Hlohovec,Trnavský,Piešťany,Hubina,522,3,0.57%,,,
-Trebišov,Košický,Košice - okolie,Bukovec,696,4,0.57%,,,
-Malacky,Trnavský,Senica,Cerová,698,4,0.57%,863,8,0.93%
-Nitra,Nitriansky,Nitra,Štefanovičová,175,1,0.57%,,,
-Malacky,Trnavský,Senica,Sobotište,878,5,0.57%,1057,1,0.09%
-Hlohovec,Trnavský,Trnava,Lošonec,527,3,0.57%,,,
-Hlohovec,Trnavský,Hlohovec,Horné Zelenice,527,3,0.57%,,,
-Hlohovec,Trnavský,Hlohovec,Horné Otrokovce,703,4,0.57%,,,
-Prešov,Prešovský,Svidník,Roztoky,176,1,0.57%,194,2,1.03%
-Žilina,Žilinský,Žilina,Porúbka,528,3,0.57%,470,3,0.64%
-Malacky,Bratislavský,Malacky,Láb,1936,11,0.57%,,,
-Sereď,Bratislavský,Senec,Kráľová pri Senci,2290,13,0.57%,,,
-Trebišov,Košický,Trebišov,Vojčice,1058,6,0.57%,,,
-Martin,Žilinský,Martin,Laskár,353,2,0.57%,329,1,0.30%
-Rožňava,Košický,Rožňava,Ardovo,353,2,0.57%,,,
-Zvolen,Banskobystrický,Krupina,Bzovík,1060,6,0.57%,,,
-Trenčín,Trenčiansky,Ilava,Krivoklát,177,1,0.56%,181,4,2.21%
-Prešov,Prešovský,Prešov,Rokycany,531,3,0.56%,519,0,0.00%
-Levice,Nitriansky,Nové Zámky,Andovce,1062,6,0.56%,,,
-Trebišov,Košický,Trebišov,Stanča,354,2,0.56%,,,
-Trebišov,Košický,Košice - okolie,Slanská Huta,177,1,0.56%,,,
-Zvolen,Banskobystrický,Žiar nad Hronom,Trnavá Hora,886,5,0.56%,,,
-Hlohovec,Trnavský,Piešťany,Bašovce,532,3,0.56%,,,
-Prešov,Prešovský,Prešov,Haniska,710,4,0.56%,680,1,0.15%
-Prešov,Prešovský,Prešov,Teriakovce,889,5,0.56%,759,3,0.40%
-Prešov,Prešovský,Bardejov,Nižná Voľa,178,1,0.56%,165,1,0.61%
-Nitra,Nitriansky,Zlaté Moravce,Čierne Kľačany,712,4,0.56%,,,
-Hlohovec,Trnavský,Trnava,Jaslovské Bohunice,1603,9,0.56%,,,
-Zvolen,Banskobystrický,Detva,Látky,536,3,0.56%,701,0,0.00%
-Malacky,Bratislavský,Pezinok,Viničné,1787,10,0.56%,,,
-Prešov,Prešovský,Poprad,Mengusovce,537,3,0.56%,471,1,0.21%
-Martin,Žilinský,Martin,Folkušová,358,2,0.56%,262,0,0.00%
-Prešov,Prešovský,Prešov,Ovčie,538,3,0.56%,494,0,0.00%
-Levice,Nitrianský,Levice,Levice,16149,90,0.56%,,,
-Sereď,Trnavský,Dunajská Streda,Čiližská Radvaň,718,4,0.56%,827,3,0.36%
-Zvolen,Banskobystrický,Žiar nad Hronom,Kremnica,2519,14,0.56%,,,
-Levice,Nitriansky,Nové Zámky,Rastislavice,720,4,0.56%,,,
-Zvolen,Banskobystrický,Lučenec,Halič,1266,7,0.55%,,,
-Rožňava,Košický,Rimavská Sobota,Stará Bašta,181,1,0.55%,,,
-Malacky,Bratislavský,Malacky,Borinka,905,5,0.55%,,,
-Martin,Žilinský,Námestovo,Vavrečka,906,5,0.55%,934,2,0.21%
-Trebišov,Košický,Košice II,Košice - Lorinčík,1088,6,0.55%,,,
-Sereď,Trnavský,Dunajská Streda,Rohovce,908,5,0.55%,1100,7,0.64%
-Malacky,Trnavský,Skalica,Gbely,3091,17,0.55%,3274,15,0.46%
-Nitra,Nitriansky,Šaľa,Diakovce,2182,12,0.55%,,,
-Martin,Žilinský,Martin,Turčianské Jaseno,364,2,0.55%,370,2,0.54%
-Rožňava,Košický,Rožňava,Dedinky,182,1,0.55%,,,
-Zvolen,Banskobystrický,Lučenec,Tuhár,364,2,0.55%,,,
-Topoľčany,Nitriansky,Topoľčany,Nitrianska Streda,547,3,0.55%,620,3,0.48%
-Hlohovec,Trnavský,Trnava,Brestovany,1460,8,0.55%,,,
-Rožňava,Košický,Rožňava,Jablonov nad Turňou,548,3,0.55%,,,
-Trebišov,Košický,Košice - okolie,Milhosť,183,1,0.55%,,,
-Sereď,Trnavský,Dunajská Streda,Oľdza,734,4,0.54%,1163,4,0.34%
-Sereď,Bratislavský,Senec,Miloslavov,4590,25,0.54%,,,
-Rožňava,Košický,Revúca,Chvalová,184,1,0.54%,,,
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Kočovce,1289,7,0.54%,1360,3,0.22%
-Malacky,Trnavský,Senica,Hradište pod Vrátnom,553,3,0.54%,605,1,0.17%
-Malacky,Bratislavský,Malacky,Plavecký Štvrtok,2214,12,0.54%,,,
-Rožňava,Košický,Gelnica,Nálepkovo,1665,9,0.54%,1787,17,0.95%
-Michalovce,Prešovský,Vranov nad Topľou,Poša,555,3,0.54%,581,2,0.34%
-Sereď,Trnavský,Dunajská Streda,Hviezdoslavov,2222,12,0.54%,3836,18,0.47%
-Zvolen,Banskobystrický,Žarnovica,Nová Baňa,3706,20,0.54%,,,
-Malacky,Bratislavský,Pezinok,Báhoň,1486,8,0.54%,,,
-Nitra,Nitriansky,Nitra,Vráble,5574,30,0.54%,,,
-Prešov,Prešovský,Svidník,Stročín,186,1,0.54%,187,1,0.53%
-Levice,Nitrianský,Komárno,Kolárovo,6514,35,0.54%,,,
-Nitra,Nitriansky,Šaľa,Vlčany,2234,12,0.54%,,,
-Malacky,Bratislavský,Malacky,Rohožník,2796,15,0.54%,,,
-Nitra,Nitriansky,Zlaté Moravce,Červený Hrádok,373,2,0.54%,,,
-Prešov,Prešovský,Kežmarok,Holumnica,560,3,0.54%,508,1,0.20%
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Bošáca,749,4,0.53%,743,1,0.13%
-Nitra,Nitriansky,Zlaté Moravce,Choča,562,3,0.53%,,,
-Prešov,Prešovský,Prešov,Radatice,563,3,0.53%,531,1,0.19%
-Martin,Žilinský,Martin,Slovany,376,2,0.53%,360,2,0.56%
-Trebišov,Košický,Košice - okolie,Ruskov,941,5,0.53%,,,
-Trebišov,Košický,Košice IV,Košice - Nad jazerom,11109,59,0.53%,,,
-Levice,Nitrianský,Levice,Čaka,566,3,0.53%,,,
-Rožňava,Košický,Revúca,Gemerská Ves,566,3,0.53%,,,
-Rožňava,Košický,Rožňava,Honce,189,1,0.53%,,,
-Zvolen,Banskobystrický,Krupina,Sebechleby,759,4,0.53%,,,
-Zvolen,Banskobystrický,Zvolen,Lieskovec,949,5,0.53%,955,2,0.21%
-Rožňava,Košický,Spišská Nová Ves,Danišovce,570,3,0.53%,477,1,0.21%
-Michalovce,Prešovský,Vranov nad Topľou,Merník,570,3,0.53%,567,1,0.18%
-Hlohovec,Trnavský,Piešťany,Ducové,190,1,0.53%,,,
-Nitra,Nitriansky,Zlaté Moravce,Zlaté Moravce,6468,34,0.53%,,,
-Malacky,Bratislavský,Pezinok,Častá,1525,8,0.52%,,,
-Michalovce,Košický,Michalovce,Vinné,1335,7,0.52%,1370,4,0.29%
-Sereď,Trnavský,Galanta,Košúty,1145,6,0.52%,,,
-Bratislava,Bratislavský,Bratislava IV,Bratislava - Lamač,4964,26,0.52%,,,
-Levice,Nitriansky,Nové Zámky,Nové Zámky,18549,97,0.52%,,,
-Sereď,Bratislavský,Senec,Rovinka,3635,19,0.52%,,,
-Levice,Nitrianský,Komárno,Svätý Peter,1914,10,0.52%,,,
-Ružomberok,Žilinský,Liptovský Mikuláš,Liptovský Trnovec,575,3,0.52%,556,4,0.72%
-Trebišov,Košický,Košice - okolie,Geča,1151,6,0.52%,,,
-Sereď,Trnavský,Galanta,Abrahám,960,5,0.52%,,,
-Hlohovec,Trnavský,Piešťany,Piešťany,15216,79,0.52%,,,
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Potvorice,771,4,0.52%,996,6,0.60%
-Nitra,Nitriansky,Nitra,Cabaj - Čápor,2507,13,0.52%,,,
-Prešov,Prešovský,Bardejov,Rešov,193,1,0.52%,212,0,0.00%
-Trebišov,Košický,Košice - okolie,Nižná Kamenica,579,3,0.52%,,,
-Sereď,Bratislavský,Senec,Senec,10423,54,0.52%,,,
-Prešov,Prešovský,Prešov,Kendice,1160,6,0.52%,1546,11,0.71%
-Levice,Nitrianský,Komárno,Číčov,774,4,0.52%,,,
-Prešov,Prešovský,Prešov,Janov,194,1,0.52%,193,0,0.00%
-Michalovce,Prešovský,Humenné,Jabloň,388,2,0.52%,289,0,0.00%
-Rožňava,Košický,Rožňava,Rejdová,582,3,0.52%,,,
-Rožňava,Košický,Rimavská Sobota,Kraskovo,194,1,0.52%,,,
-Žilina,Žilinský,Kysucké Nové Mesto,Lopušné Pažite,583,3,0.51%,293,3,1.02%
-Michalovce,Prešovský,Vranov nad Topľou,Vechec,1945,10,0.51%,1022,2,0.20%
-Zvolen,Banskobystrický,Veľký Krtíš,Nenince,778,4,0.51%,,,
-Rožňava,Košický,Poltár,Kalinovo,1363,7,0.51%,,,
-Trenčín,Trenčiansky,Trenčín,Opatovce,390,2,0.51%,346,1,0.29%
-Martin,Žilinský,Martin,Ležiachov,195,1,0.51%,206,0,0.00%
-Levice,Nitriansky,Nové Zámky,Kmeťovo,585,3,0.51%,,,
-Trebišov,Košický,Košice - okolie,Budimír,978,5,0.51%,,,
-Zvolen,Banskobystrický,Zvolen,Veľká Lúka,588,3,0.51%,526,0,0.00%
-Zvolen,Banskobystrický,Žiar nad Hronom,Dolná Ždaňa,589,3,0.51%,,,
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Haláčovce,197,1,0.51%,217,2,0.92%
-Prešov,Prešovský,Prešov,Ruská Nová Ves,985,5,0.51%,936,3,0.32%
-Zvolen,Banskobystrický,Lučenec,Mučín,591,3,0.51%,,,
-Sereď,Trnavský,Galanta,Sereď,9873,50,0.51%,,,
-Zvolen,Banskobystrický,Banská Bystrica,Badín,1580,8,0.51%,1455,4,0.27%
-Levice,Nitriansky,Nové Zámky,Štúrovo,4554,23,0.51%,,,
-Prešov,Prešovský,Bardejov,Becherov,397,2,0.50%,275,0,0.00%
-Prešov,Prešovský,Svidník,Krajná Poľana,199,1,0.50%,70,0,0.00%
-Rožňava,Košický,Poltár,Zlatno,199,1,0.50%,,,
-Hlohovec,Trnavský,Trnava,Suchá nad Parnou,2191,11,0.50%,,,
-Zvolen,Banskobystrický,Brezno,Bacúch,598,3,0.50%,653,1,0.15%
-Malacky,Bratislavský,Pezinok,Dubová,997,5,0.50%,,,
-Levice,Nitriansky,Nové Zámky,Bíňa,798,4,0.50%,,,
-Trenčín,Trenčiansky,Ilava,Mikušovce,799,4,0.50%,697,1,0.14%
-Sereď,Trnavský,Galanta,Čierny Brod,1200,6,0.50%,,,
-Zvolen,Banskobystrický,Lučenec,Fiľakovo,5607,28,0.50%,,,
-Hlohovec,Trnavský,Piešťany,Veselé,802,4,0.50%,,,
-Levice,Nitriansky,Nové Zámky,Tvrdošovce,2411,12,0.50%,,,
-Ružomberok,Žilinský,Ružomberok,Martinček,201,1,0.50%,203,0,0.00%
-Michalovce,Prešovský,Medzilaborce,Volica,201,1,0.50%,207,0,0.00%
-Hlohovec,Trnavský,Piešťany,Šípkové,201,1,0.50%,,,
-Sereď,Bratislavský,Senec,Ivanka pri Dunaji,5435,27,0.50%,,,
-Prešov,Prešovský,Poprad,Kravany,604,3,0.50%,573,1,0.17%
-Trenčín,Trenčiansky,Ilava,Borčice,605,3,0.50%,558,1,0.18%
-Malacky,Trnavský,Senica,Bílkove Humence,202,1,0.50%,266,0,0.00%
-Rožňava,Košický,Rimavská Sobota,Hodejov,1011,5,0.49%,,,
-Michalovce,Košický,Michalovce,Ruská,405,2,0.49%,516,2,0.39%
-Zvolen,Banskobystrický,Veľký Krtíš,Koláre + Chrastince,203,1,0.49%,,,
-Zvolen,Banskobystrický,Detva,Vígľaš,1016,5,0.49%,1083,4,0.37%
-Levice,Nitrianský,Komárno,Veľké Kosihy,1016,5,0.49%,,,
-Hlohovec,Trnavský,Trnava,Zvončín,813,4,0.49%,,,
-Michalovce,Košický,Michalovce,Rakovec nad Ondavou,611,3,0.49%,588,0,0.00%
-Nitra,Nitriansky,Šaľa,Neded,2038,10,0.49%,,,
-Prešov,Prešovský,Bardejov,Gaboltov,204,1,0.49%,205,3,1.46%
-Topoľčany,Nitriansky,Topoľčany,Nemečky,204,1,0.49%,229,1,0.44%
-Levice,Nitriansky,Nové Zámky,Bardoňovo. Pozba,613,3,0.49%,,,
-Zvolen,Banskobystrický,Krupina,Cerovo,409,2,0.49%,,,
-Sereď,Trnavský,Dunajská Streda,Horné Mýto,615,3,0.49%,902,2,0.22%
-Nitra,Nitriansky,Nitra,Nové Sady,820,4,0.49%,,,
-Trebišov,Košický,Košice - okolie,Družstevná pri Hornáde,1435,7,0.49%,,,
-Sereď,Bratislavský,Senec,Veľký Biel,3280,16,0.49%,,,
-Zvolen,Banskobystrický,Detva,Detvianska Huta,618,3,0.49%,686,1,0.15%
-Zvolen,Banskobystrický,Banská Bystrica,Poniky,1030,5,0.49%,1123,1,0.09%
-Levice,Nitriansky,Nové Zámky,Palárikovo,2475,12,0.48%,,,
-Trebišov,Košický,Košice - okolie,Rozhanovce,1444,7,0.48%,,,
-Trebišov,Košický,Trebišov,Pribeník,619,3,0.48%,,,
-Nitra,Nitriansky,Nitra,Lukáčovce,826,4,0.48%,,,
-Zvolen,Banskobystrický,Zvolen,Zvolenská Slatina,1859,9,0.48%,1873,10,0.53%
-Levice,Nitrianský,Levice,Jur nad Hronom. Žemliare,828,4,0.48%,,,
-Zvolen,Banskobystrický,Žarnovica,Žarnovica,2916,14,0.48%,,,
-Rožňava,Košický,Gelnica,Žakarovce,417,2,0.48%,367,0,0.00%
-Trebišov,Košický,Trebišov,Strážne,417,2,0.48%,,,
-Martin,Žilinský,Námestovo,Vasiľov,626,3,0.48%,598,3,0.50%
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Haluzice,418,2,0.48%,155,1,0.65%
-Rožňava,Košický,Spišská Nová Ves,Hnilec,418,2,0.48%,407,0,0.00%
-Zvolen,Banskobystrický,Žiar nad Hronom,Bzenica,418,2,0.48%,,,
-Levice,Nitriansky,Nové Zámky,Veľký Kýr,1888,9,0.48%,,,
-Sereď,Bratislavský,Senec,Tureň,1259,6,0.48%,,,
-Trebišov,Košický,Košice - okolie,Kechnec,1680,8,0.48%,,,
-Trebišov,Košický,Košice - okolie,Turňa nad Bodvou,1682,8,0.48%,,,
-Zvolen,Banskobystrický,Krupina,Čekovce,421,2,0.48%,,,
-Prešov,Prešovský,Bardejov,Komárov,211,1,0.47%,243,1,0.41%
-Michalovce,Prešovský,Medzilaborce,Zbudská Belá,422,2,0.47%,149,0,0.00%
-Zvolen,Banskobystrický,Žarnovica,Hrabičov,422,2,0.47%,,,
-Malacky,Bratislavský,Malacky,Veľké Leváre,2747,13,0.47%,,,
-Nitra,Nitriansky,Zlaté Moravce,Hosťovce,634,3,0.47%,,,
-Sereď,Trnavský,Dunajská Streda,Potônske Lúky,423,2,0.47%,382,1,0.26%
-Rožňava,Košický,Rimavská Sobota,Lenka + Hubovo,423,2,0.47%,,,
-Levice,Nitrianský,Levice,Veľké Kozmálovce,638,3,0.47%,,,
-Sereď,Trnavský,Galanta,Veľký Grob,1064,5,0.47%,,,
-Nitra,Nitriansky,Zlaté Moravce,Sľažany,639,3,0.47%,,,
-Trebišov,Košický,Košice - okolie,Čižatice,213,1,0.47%,,,
-Zvolen,Banskobystrický,Lučenec,Podrečany,426,2,0.47%,,,
-Nitra,Nitriansky,Nitra,Pohranice,855,4,0.47%,,,
-Nitra,Nitriansky,Nitra,Štitáre,855,4,0.47%,,,
-Bratislava,Bratislavský,Bratislava IV,Bratislava - Devínska Nová Ves,10903,51,0.47%,,,
-Trebišov,Košický,Košice - okolie,Slanec + Slančík,1069,5,0.47%,,,
-Hlohovec,Trnavský,Piešťany,Banka,1501,7,0.47%,,,
-Nitra,Nitriansky,Nitra,Lúčnica nad Žitavou,644,3,0.47%,,,
-Ružomberok,Žilinský,Liptovský Mikuláš,Jalovec,215,1,0.47%,215,4,1.86%
-Žilina,Žilinský,Žilina,Paština Závada,216,1,0.46%,202,2,0.99%
-Prešov,Prešovský,Prešov,Demjata,648,3,0.46%,719,4,0.56%
-Zvolen,Banskobystrický,Lučenec,Dobroč,432,2,0.46%,,,
-Martin,Žilinský,Turčianske Teplice,Malý Čepčín,433,2,0.46%,412,5,1.21%
-Michalovce,Košický,Michalovce,Veľké Slemence,433,2,0.46%,431,2,0.46%
-Rožňava,Košický,Rožňava,Rakovnica,433,2,0.46%,,,
-Levice,Nitrianský,Komárno,Bátorové Kosihy,2167,10,0.46%,,,
-Zvolen,Banskobystrický,Krupina,Krupina,3903,18,0.46%,,,
-Prešov,Prešovský,Prešov,Krížovany,217,1,0.46%,175,0,0.00%
-Trebišov,Košický,Košice - okolie,Paňovce,652,3,0.46%,,,
-Michalovce,Košický,Sobrance,Vyšné Remety,436,2,0.46%,442,2,0.45%
-Levice,Nitriansky,Nové Zámky,Hul. Vlkas,872,4,0.46%,,,
-Rožňava,Košický,Rožňava,Gemerská Panica,654,3,0.46%,,,
-Sereď,Trnavský,Dunajská Streda,Holice,1528,7,0.46%,1697,4,0.24%
-Levice,Nitrianský,Levice,Dolný Pial. Horný Pial,656,3,0.46%,,,
-Rožňava,Košický,Rimavská Sobota,Hajnáčka,656,3,0.46%,,,
-Hlohovec,Trnavský,Hlohovec,Leopoldov,2626,12,0.46%,,,
-Trebišov,Košický,Košice IV,Košice - Barca,2189,10,0.46%,,,
-Topoľčany,Trenčiansky,Partizánske,Ježková Ves,219,1,0.46%,416,3,0.72%
-Hlohovec,Trnavský,Trnava,Dobrá Voda,659,3,0.46%,,,
-Nitra,Nitriansky,Nitra,Žitavce,441,2,0.45%,,,
-Nitra,Nitriansky,Nitra,Lehota,1766,8,0.45%,,,
-Trenčín,Trenčiansky,Myjava,Priepasné,221,1,0.45%,212,0,0.00%
-Levice,Nitriansky,Nové Zámky,Komoča,888,4,0.45%,,,
-Trebišov,Košický,Košice - okolie,Baška,1776,8,0.45%,,,
-Rožňava,Košický,Rožňava,Hrhov,667,3,0.45%,,,
-Sereď,Bratislavský,Senec,Nová Dedinka,2225,10,0.45%,,,
-Prešov,Prešovský,Levoča,Ordzovany,223,1,0.45%,231,2,0.87%
-Rožňava,Košický,Gelnica,Švedlár,1117,5,0.45%,1006,4,0.40%
-Sereď,Bratislavský,Senec,Zálesie,1791,8,0.45%,,,
-Rožňava,Košický,Rimavská Sobota,Čerenčany,448,2,0.45%,,,
-Levice,Nitriansky,Nové Zámky,Semerovo,897,4,0.45%,,,
-Michalovce,Prešovský,Vranov nad Topľou,Petrovce,450,2,0.44%,422,5,1.18%
-Zvolen,Banskobystrický,Lučenec,Rapovce,675,3,0.44%,,,
-Hlohovec,Trnavský,Hlohovec,Sasinkovo,681,3,0.44%,,,
-Levice,Nitrianský,Levice,Hrkovce,227,1,0.44%,,,
-Trebišov,Košický,Košice - okolie,Hrašovík,227,1,0.44%,,,
-Ružomberok,Žilinský,Liptovský Mikuláš,Huty,228,1,0.44%,224,4,1.79%
-Trebišov,Košický,Trebišov,Egreš,228,1,0.44%,,,
-Nitra,Nitriansky,Nitra,Golianovo,1598,7,0.44%,,,
-Zvolen,Banskobystrický,Banská Bystrica,Horná Mičiná,685,3,0.44%,576,3,0.52%
-Zvolen,Banskobystrický,Banská Bystrica,Hronsek,686,3,0.44%,586,0,0.00%
-Malacky,Bratislavský,Malacky,Suchohrad,686,3,0.44%,,,
-Zvolen,Banskobystrický,Lučenec,Veľká nad Ipľom,688,3,0.44%,,,
-Rožňava,Košický,Rimavská Sobota,Tisovec,2301,10,0.43%,,,
-Zvolen,Banskobystrický,Detva,Kriváň,1381,6,0.43%,1633,10,0.61%
-Malacky,Bratislavský,Malacky,Závod,2075,9,0.43%,,,
-Nitra,Nitriansky,Zlaté Moravce,Nemčiňany,462,2,0.43%,,,
-Levice,Nitriansky,Nové Zámky,Bruty,462,2,0.43%,,,
-Trebišov,Košický,Košice I,Košice - Sever,9480,41,0.43%,,,
-Hlohovec,Trnavský,Piešťany,Rakovice,694,3,0.43%,,,
-Prešov,Prešovský,Sabinov,Ostrovany,1157,5,0.43%,1083,6,0.55%
-Michalovce,Prešovský,Vranov nad Topľou,Sačurov,1389,6,0.43%,1560,7,0.45%
-Ružomberok,Žilinský,Liptovský Mikuláš,Lazisko,232,1,0.43%,251,1,0.40%
-Zvolen,Banskobystrický,Banská Štiavnica,Banská Belá,696,3,0.43%,,,
-Malacky,Bratislavský,Pezinok,Budmerice,2322,10,0.43%,,,
-Levice,Nitriansky,Nové Zámky,Belá. Ľubá,697,3,0.43%,,,
-Sereď,Trnavský,Galanta,Sládkovičovo,3954,17,0.43%,,,
-Trebišov,Košický,Trebišov,Streda nad Bodrogom,1163,5,0.43%,,,
-Zvolen,Banskobystrický,Lučenec,Vidiná,1164,5,0.43%,,,
-Levice,Nitrianský,Komárno,Imeľ,1864,8,0.43%,,,
-Rožňava,Košický,Revúca,Lubeník,699,3,0.43%,,,
-Žilina,Žilinský,Žilina,Lietavská Lúčka,1166,5,0.43%,1284,8,0.62%
-Malacky,Trnavský,Senica,Dojč,469,2,0.43%,766,3,0.39%
-Nitra,Nitriansky,Nitra,Vinodol,1643,7,0.43%,,,
-Michalovce,Košický,Michalovce,Zalužice,939,4,0.43%,896,0,0.00%
-Malacky,Trnavský,Senica,Rovensko,470,2,0.43%,312,0,0.00%
-Michalovce,Košický,Michalovce,Veľké Kapušany,4475,19,0.42%,5649,19,0.34%
-Hlohovec,Trnavský,Trnava,Bohdanovce nad Trnavou,943,4,0.42%,,,
-Sereď,Trnavský,Dunajská Streda,Kľúčovec,236,1,0.42%,534,2,0.37%
-Nitra,Nitriansky,Nitra,Babindol,947,4,0.42%,,,
-Prešov,Prešovský,Stropkov,Lomné,237,1,0.42%,170,3,1.76%
-Michalovce,Prešovský,Medzilaborce,Ňagov,237,1,0.42%,241,1,0.41%
-Malacky,Bratislavský,Malacky,Lozorno,2141,9,0.42%,,,
-Rožňava,Košický,Rimavská Sobota,Gemerský Jablonec,476,2,0.42%,,,
-Rožňava,Košický,Poltár,České Brezovo,238,1,0.42%,,,
-Nitra,Nitriansky,Šaľa,Šaľa,12632,53,0.42%,,,
-Sereď,Bratislavský,Senec,Hamuliakovo,2148,9,0.42%,,,
-Trebišov,Košický,Košice II,Košice - Sídlisko KVP,8608,36,0.42%,,,
-Rožňava,Košický,Rimavská Sobota,Gemerské Dechtáre,240,1,0.42%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Olováry,240,1,0.42%,,,
-Trebišov,Košický,Košice - okolie,Poproč,1442,6,0.42%,,,
-Zvolen,Banskobystrický,Zvolen,Podzámčok,482,2,0.41%,495,0,0.00%
-Martin,Žilinský,Martin,Trebostovo,483,2,0.41%,463,0,0.00%
-Rožňava,Košický,Rožňava,Kobeliarovo,242,1,0.41%,,,
-Bratislava,Bratislavský,Bratislava V,Bratislava - Petržalka,58918,243,0.41%,,,
-Martin,Žilinský,Dolný Kubín,Veličná,970,4,0.41%,986,5,0.51%
-Hlohovec,Trnavský,Piešťany,Ostrov,729,3,0.41%,,,
-Bratislava,Bratislavský,Bratislava V,Bratislava - Jarovce,2692,11,0.41%,,,
-Nitra,Nitriansky,Nitra,Čechynce,979,4,0.41%,,,
-Zvolen,Banskobystrický,Lučenec,Ábelová,245,1,0.41%,,,
-Levice,Nitrianský,Levice,Želiezovce,3186,13,0.41%,,,
-Trebišov,Košický,Košice III,Košice - Dargovských hrdinov,9568,39,0.41%,,,
-Sereď,Trnavský,Dunajská Streda,Vieska,246,1,0.41%,300,0,0.00%
-Malacky,Bratislavský,Malacky,Gajary,1970,8,0.41%,,,
-Hlohovec,Trnavský,Hlohovec,Červeník,988,4,0.40%,,,
-Malacky,Bratislavský,Malacky,Záhorská Ves,1235,5,0.40%,,,
-Michalovce,Prešovský,Vranov nad Topľou,Davidov,496,2,0.40%,520,2,0.38%
-Nitra,Nitriansky,Nitra,Čakajovce,744,3,0.40%,,,
-Michalovce,Prešovský,Vranov nad Topľou,Matiaška,498,2,0.40%,500,8,1.60%
-Trebišov,Košický,Trebišov,Viničky,249,1,0.40%,,,
-Hlohovec,Trnavský,Trnava,Zeleneč,1744,7,0.40%,,,
-Rožňava,Košický,Rimavská Sobota,Rimavská Sobota,9984,40,0.40%,,,
-Prešov,Prešovský,Prešov,Lesíček,250,1,0.40%,254,1,0.39%
-Michalovce,Košický,Michalovce,Ložín,501,2,0.40%,510,0,0.00%
-Levice,Nitrianský,Levice,Čajkov,753,3,0.40%,,,
-Levice,Nitrianský,Levice,Hotianská Vrbica,504,2,0.40%,,,
-Rožňava,Košický,Rimavská Sobota,Dolné Zahorany,252,1,0.40%,,,
-Trebišov,Košický,Košice - okolie,Rudník,504,2,0.40%,,,
-Michalovce,Prešovský,Vranov nad Topľou,Vyšný Žipov,758,3,0.40%,785,4,0.51%
-Sereď,Bratislavský,Senec,Čataj,1011,4,0.40%,,,
-Trebišov,Košický,Trebišov,Slovenské Nové Mesto,759,3,0.40%,,,
-Trebišov,Košický,Košice IV,Košice - Krásna,3038,12,0.39%,,,
-Michalovce,Košický,Michalovce,Drahňov,760,3,0.39%,712,1,0.14%
-Levice,Nitriansky,Nové Zámky,Branovo,761,3,0.39%,,,
-Nitra,Nitriansky,Zlaté Moravce,Žitavany,1269,5,0.39%,,,
-Levice,Nitriansky,Nové Zámky,Michal n/Žitavou,764,3,0.39%,,,
-Rožňava,Košický,Revúca,Tornaľa,3569,14,0.39%,,,
-Sereď,Trnavský,Dunajská Streda,Mierovo,255,1,0.39%,445,1,0.22%
-Zvolen,Banskobystrický,Žiar nad Hronom,Hronská Dúbrava,255,1,0.39%,,,
-Nitra,Nitriansky,Nitra,Rišňovce,1533,6,0.39%,,,
-Levice,Nitrianský,Levice,Šarovce,1023,4,0.39%,,,
-Rožňava,Košický,Revúca,Otročok,256,1,0.39%,,,
-Trebišov,Košický,Trebišov,Čeľovce,770,3,0.39%,,,
-Zvolen,Banskobystrický,Brezno,Braväcovo,514,2,0.39%,571,1,0.18%
-Hlohovec,Trnavský,Trnava,Šúrovce,1543,6,0.39%,,,
-Trebišov,Košický,Košice - okolie,Kecerovský Lipovec+ Mudrovce,258,1,0.39%,,,
-Zvolen,Banskobystrický,Žiar nad Hronom,Stará Kremnička,774,3,0.39%,,,
-Zvolen,Banskobystrický,Lučenec,Ľuboreč,258,1,0.39%,,,
-Trebišov,Košický,Košice - okolie,Jasov,2065,8,0.39%,,,
-Zvolen,Banskobystrický,Detva,Slatinské Lazy,517,2,0.39%,460,0,0.00%
-Levice,Nitriansky,Nové Zámky,Veľké Lovce,1035,4,0.39%,,,
-Rožňava,Košický,Poltár,Cinobaňa,1296,5,0.39%,,,
-Michalovce,Prešovský,Vranov nad Topľou,Hermanovce nad Topľou,520,2,0.38%,523,0,0.00%
-Rožňava,Košický,Gelnica,Prakovce,1563,6,0.38%,1616,4,0.25%
-Nitra,Nitriansky,Nitra,Malý Cetín,525,2,0.38%,,,
-Zvolen,Banskobystrický,Žarnovica,Tekovská Breznica,788,3,0.38%,,,
-Trebišov,Košický,Trebišov,Plechotice,528,2,0.38%,,,
-Michalovce,Prešovský,Vranov nad Topľou,Ondavské Matiašovce,529,2,0.38%,533,1,0.19%
-Levice,Nitrianský,Levice,Tekovské Lužany,1852,7,0.38%,,,
-Sereď,Trnavský,Dunajská Streda,Šamorín,7942,30,0.38%,12773,49,0.38%
-Zvolen,Banskobystrický,Krupina,Kráľovce - Krnišov,265,1,0.38%,,,
-Sereď,Trnavský,Dunajská Streda,Hubice,531,2,0.38%,487,10,2.05%
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Častkovce,1064,4,0.38%,996,5,0.50%
-Trebišov,Košický,Košice - okolie,Ďurkov,1068,4,0.37%,,,
-Trebišov,Košický,Košice - okolie,Nižný Klátov,535,2,0.37%,,,
-Trebišov,Košický,Trebišov,Trebišov,13385,50,0.37%,,,
-Bratislava,Bratislavský,Bratislava III,Bratislava - Nové Mesto,29460,110,0.37%,,,
-Zvolen,Banskobystrický,Lučenec,Veľké Dravce,536,2,0.37%,,,
-Levice,Nitriansky,Nové Zámky,Úľany nad Žitavou,1076,4,0.37%,,,
-Trebišov,Košický,Trebišov,Leles 1 - Leles3,538,2,0.37%,,,
-Trebišov,Košický,Košice - okolie,Obišovce,538,2,0.37%,,,
-Sereď,Bratislavský,Senec,Chorvátsky Grob,5650,21,0.37%,,,
-Levice,Nitriansky,Nové Zámky,Jasová,809,3,0.37%,,,
-Trenčín,Trenčiansky,Považská Bystrica,Bodiná,270,1,0.37%,279,1,0.36%
-Trenčín,Trenčiansky,Ilava,Kameničany,270,1,0.37%,307,1,0.33%
-Michalovce,Košický,Michalovce,Dúbravka,542,2,0.37%,511,3,0.59%
-Hlohovec,Trnavský,Hlohovec,Trakovice,1085,4,0.37%,,,
-Nitra,Nitriansky,Nitra,Klasov,815,3,0.37%,,,
-Malacky,Bratislavský,Pezinok,Vištuk,1090,4,0.37%,,,
-Martin,Žilinský,Dolný Kubín,Istebné,820,3,0.37%,889,4,0.45%
-Prešov,Prešovský,Svidník,Krajná Bystrá,274,1,0.36%,277,1,0.36%
-Hlohovec,Trnavský,Trnava,Voderady,1098,4,0.36%,,,
-Michalovce,Košický,Michalovce,Kapušianské Kľačany,550,2,0.36%,555,3,0.54%
-Trenčín,Trenčiansky,Púchov,Beluša - Podhorie,275,1,0.36%,270,0,0.00%
-Trebišov,Košický,Košice - okolie,Šemša,552,2,0.36%,,,
-Levice,Nitriansky,Nové Zámky,Gbelce,1384,5,0.36%,,,
-Zvolen,Banskobystrický,Lučenec,Šurice,277,1,0.36%,,,
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Pobedim,832,3,0.36%,1235,6,0.49%
-Levice,Nitrianský,Komárno,Kameničná,1389,5,0.36%,,,
-Bratislava,Bratislavský,Bratislava I,Bratislava - Staré Mesto,28614,103,0.36%,,,
-Prešov,Prešovský,Stropkov,Nižná Olšava,278,1,0.36%,268,4,1.49%
-Rožňava,Košický,Rimavská Sobota,Blhovce,559,2,0.36%,,,
-Levice,Nitrianský,Levice,Kuraľany,280,1,0.36%,,,
-Levice,Nitrianský,Levice,Rybník,841,3,0.36%,,,
-Žilina,Žilinský,Žilina,Stránske,562,2,0.36%,536,4,0.75%
-Malacky,Bratislavský,Malacky,Záhorie (vojenský obvod),281,1,0.36%,,,
-Zvolen,Banskobystrický,Žarnovica,Rudno nad Hronom,562,2,0.36%,,,
-Hlohovec,Trnavský,Trnava,Horná Krupá,565,2,0.35%,,,
-Bratislava,Bratislavský,Bratislava II,Bratislava - Ružinov,55677,197,0.35%,,,
-Zvolen,Banskobystrický,Lučenec,Kotmanová,283,1,0.35%,,,
-Trebišov,Košický,Trebišov,Kráľovský Chlmec,3700,13,0.35%,,,
-Rožňava,Košický,Spišská Nová Ves,Odorín,854,3,0.35%,791,4,0.51%
-Levice,Nitrianský,Levice,Beša,570,2,0.35%,,,
-Rožňava,Košický,Rožňava,Hrušov,285,1,0.35%,,,
-Rožňava,Košický,Rimavská Sobota,Stránska,286,1,0.35%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Balog nad Ipľom,572,2,0.35%,,,
-Nitra,Nitriansky,Šaľa,Trnovec,2299,8,0.35%,,,
-Levice,Nitrianský,Levice,Tehla. Lula,575,2,0.35%,,,
-Rožňava,Košický,Rimavská Sobota,Kráľ,575,2,0.35%,,,
-Nitra,Nitriansky,Zlaté Moravce,Martin nad Žitavou,579,2,0.35%,,,
-Hlohovec,Trnavský,Trnava,Dechtice,1159,4,0.35%,,,
-Sereď,Trnavský,Dunajská Streda,Trhová Hradská,1746,6,0.34%,2085,1,0.05%
-Bratislava,Bratislavský,Bratislava IV,Bratislava - Záhorská Bystrica,5271,18,0.34%,,,
-Levice,Nitrianský,Levice,Farná,879,3,0.34%,,,
-Rožňava,Košický,Rožňava,Bretka,293,1,0.34%,,,
-Prešov,Prešovský,Prešov,Svinia,1175,4,0.34%,1332,0,0.00%
-Trebišov,Košický,Košice - okolie,Košická Belá,883,3,0.34%,,,
-Nitra,Nitriansky,Zlaté Moravce,Topoľčianky,1473,5,0.34%,,,
-Bratislava,Bratislavský,Bratislava III,Bratislava - Rača,15955,54,0.34%,,,
-Trebišov,Košický,Košice - okolie,Bohdanovce,592,2,0.34%,,,
-Levice,Nitrianský,Komárno,Búč,890,3,0.34%,,,
-Bratislava,Bratislavský,Bratislava IV,Bratislava - Karlova Ves,24044,81,0.34%,,,
-Levice,Nitriansky,Nové Zámky,Maňa,1490,5,0.34%,,,
-Malacky,Bratislavský,Malacky,Kuchyňa,1490,5,0.34%,,,
-Levice,Nitrianský,Levice,Starý Tekov,1196,4,0.33%,,,
-Trebišov,Košický,Košice - okolie,Svinica,598,2,0.33%,,,
-Sereď,Trnavský,Dunajská Streda,Dobrohošť,600,2,0.33%,776,1,0.13%
-Nitra,Nitriansky,Zlaté Moravce,Čaradice,300,1,0.33%,,,
-Trebišov,Košický,Trebišov,Zemplínsky Branč,300,1,0.33%,,,
-Martin,Žilinský,Turčianske Teplice,Mošovce,902,3,0.33%,892,2,0.22%
-Levice,Nitrianský,Komárno,Kravany nad Dunajom,602,2,0.33%,,,
-Malacky,Bratislavský,Malacky,Jakubov,1204,4,0.33%,,,
-Prešov,Prešovský,Bardejov,Marhaň,603,2,0.33%,649,1,0.15%
-Michalovce,Košický,Sobrance,Bunkovce,302,1,0.33%,293,0,0.00%
-Prešov,Prešovský,Bardejov,Cigeľka,303,1,0.33%,313,0,0.00%
-Prešov,Prešovský,Bardejov,Stebník,303,1,0.33%,316,0,0.00%
-Levice,Nitrianský,Levice,Veľký Ďur,910,3,0.33%,,,
-Malacky,Bratislavský,Pezinok,Šenkvice,3039,10,0.33%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Veľký Krtíš,4869,16,0.33%,,,
-Michalovce,Košický,Michalovce,Nacina Ves,1218,4,0.33%,1133,2,0.18%
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Lubina,1525,5,0.33%,1595,2,0.13%
-Hlohovec,Trnavský,Hlohovec,Žlkovce,610,2,0.33%,,,
-Rožňava,Košický,Poltár,Ozdín,305,1,0.33%,,,
-Zvolen,Banskobystrický,Lučenec,Panické Dravce,611,2,0.33%,,,
-Trebišov,Košický,Košice - okolie,Vyšný Čaj,306,1,0.33%,,,
-Hlohovec,Trnavský,Hlohovec,Bojničky,1226,4,0.33%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Horné Strháre + Dolné Strháre,308,1,0.32%,,,
-Martin,Žilinský,Turčianske Teplice,Čremošné,309,1,0.32%,294,1,0.34%
-Trebišov,Košický,Košice - okolie,Kostoľany nad Hornádom,931,3,0.32%,,,
-Rožňava,Košický,Revúca,Muránska Huta,311,1,0.32%,,,
-Zvolen,Banskobystrický,Krupina,Devičie,311,1,0.32%,,,
-Sereď,Bratislavský,Senec,Kalinkovo,1558,5,0.32%,,,
-Levice,Nitriansky,Nové Zámky,Sikenička. Pavlová,624,2,0.32%,,,
-Zvolen,Banskobystrický,,mobilné tímy,4370,14,0.32%,,,
-Rožňava,Košický,Rožňava,Henkovce,313,1,0.32%,,,
-Malacky,Bratislavský,Malacky,Vysoká pri Morave,1884,6,0.32%,,,
-Zvolen,Banskobystrický,Krupina,Dolný Badín,314,1,0.32%,,,
-Sereď,Trnavský,Galanta,Galanta,10202,32,0.31%,,,
-Levice,Nitrianský,Levice,Malé Kozmálovce,320,1,0.31%,,,
-Levice,Nitrianský,Levice,Tekovský Hrádok. Turá,320,1,0.31%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Veľké Straciny + Malé Straciny,320,1,0.31%,,,
-Zvolen,Banskobystrický,Lučenec,Pinciná,320,1,0.31%,,,
-Rožňava,Košický,Revúca,Muránska Dlhá Lúka,641,2,0.31%,,,
-Prešov,Prešovský,Prešov,Gregorovce,642,2,0.31%,626,6,0.96%
-Michalovce,Košický,Michalovce,Bajany,322,1,0.31%,331,2,0.60%
-Rožňava,Košický,Gelnica,Stará Voda,323,1,0.31%,386,0,0.00%
-Michalovce,Prešovský,Vranov nad Topľou,Sečovská Polianka,1295,4,0.31%,1450,13,0.90%
-Prešov,Prešovský,Svidník,Okrúhle,326,1,0.31%,339,1,0.29%
-Nitra,Nitriansky,Nitra,Melek,326,1,0.31%,,,
-Trebišov,Košický,Košice - okolie,Bočiar,326,1,0.31%,,,
-Zvolen,Banskobystrický,Lučenec,Divín,1308,4,0.31%,,,
-Nitra,Nitriansky,Nitra,Poľný Kesov,655,2,0.31%,,,
-Levice,Nitriansky,Nové Zámky,Dubník,983,3,0.31%,,,
-Hlohovec,Trnavský,Trnava,Majcichov,1315,4,0.30%,,,
-Zvolen,Banskobystrický,Zvolen,Sielnica,987,3,0.30%,1015,1,0.10%
-Levice,Nitrianský,Levice,Hronovce. Malé Ludince. Šalov,659,2,0.30%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Dolné Plachtince,661,2,0.30%,,,
-Trenčín,Trenčiansky,Považská Bystrica,Horná Mariková,665,2,0.30%,688,4,0.58%
-Hlohovec,Trnavský,Hlohovec,Horné Trhovište,667,2,0.30%,,,
-Prešov,Prešovský,Prešov,Varhaňovce,1001,3,0.30%,1171,6,0.51%
-Sereď,Trnavský,Galanta,Matúškovo,1670,5,0.30%,,,
-Rožňava,Košický,Spišská Nová Ves,Olcnava,669,2,0.30%,674,2,0.30%
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Bzince pod Javorinou,1346,4,0.30%,1291,3,0.23%
-Prešov,Prešovský,Svidník,Rovné,338,1,0.30%,278,2,0.72%
-Bratislava,Bratislavský,Bratislava II,Bratislava - Podunajské Biskupice,12522,37,0.30%,,,
-Michalovce,Košický,Michalovce,Šamudovce,339,1,0.29%,311,0,0.00%
-Hlohovec,Trnavský,Piešťany,Drahovce,1699,5,0.29%,,,
-Michalovce,Košický,Michalovce,Tušická Nová Ves,341,1,0.29%,707,1,0.14%
-Zvolen,Banskobystrický,Lučenec,Čakanovce,684,2,0.29%,,,
-Hlohovec,Trnavský,Piešťany,Vrbové,2741,8,0.29%,,,
-Prešov,Prešovský,Prešov,Červenica,686,2,0.29%,718,4,0.56%
-Levice,Nitrianský,Komárno,Trávnik. Kližská Nemá,1030,3,0.29%,,,
-Sereď,Trnavský,Galanta,Pata,2062,6,0.29%,,,
-Rožňava,Košický,Rimavská Sobota,Kružno,344,1,0.29%,,,
-Sereď,Trnavský,Galanta,Veľké Úľany,3444,10,0.29%,,,
-Zvolen,Banskobystrický,Žiar nad Hronom,Lovčica - Trubín,1042,3,0.29%,,,
-Malacky,Bratislavský,Malacky,Kostolište,1390,4,0.29%,,,
-Hlohovec,Trnavský,Trnava,Dolné Dubové,696,2,0.29%,,,
-Malacky,Bratislavský,Malacky,Zohor,2436,7,0.29%,,,
-Zvolen,Banskobystrický,Žiar nad Hronom,Lutila,1046,3,0.29%,,,
-Zvolen,Banskobystrický,Banská Štiavnica,Banská Štiavnica,7697,22,0.29%,,,
-Zvolen,Banskobystrický,Žiar nad Hronom,Žiar nad Hronom,7717,22,0.29%,,,
-Martin,Žilinský,Dolný Kubín,Pribiš,351,1,0.28%,337,1,0.30%
-Zvolen,Banskobystrický,Krupina,Terany,352,1,0.28%,,,
-Sereď,Trnavský,Dunajská Streda,Macov,353,1,0.28%,480,2,0.42%
-Levice,Nitriansky,Nové Zámky,Lipová,1062,3,0.28%,,,
-Rožňava,Košický,Rožňava,Dlhá Ves,357,1,0.28%,,,
-Levice,Nitriansky,Nové Zámky,Zemné,1073,3,0.28%,,,
-Levice,Nitrianský,Komárno,Marcelová,2506,7,0.28%,,,
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Hôrka nad Váhom,718,2,0.28%,659,2,0.30%
-Nitra,Nitriansky,Nitra,Telince,359,1,0.28%,,,
-Rožňava,Košický,Poltár,Kokava nad Rimavicou,1437,4,0.28%,,,
-Levice,Nitriansky,Nové Zámky,Dvory n/Žitavou,3234,9,0.28%,,,
-Hlohovec,Trnavský,Trnava,Cífer,3595,10,0.28%,,,
-Sereď,Trnavský,Dunajská Streda,Kvetoslavov,1442,4,0.28%,2436,7,0.29%
-Levice,Nitrianský,Levice,Pohronský Ruskov,721,2,0.28%,,,
-Trebišov,Košický,Košice - okolie,Kokšov - Bakša,721,2,0.28%,,,
-Levice,Nitrianský,Komárno,Chotín,1082,3,0.28%,,,
-Rožňava,Košický,Rimavská Sobota,Teplý Vrch,361,1,0.28%,,,
-Zvolen,Banskobystrický,Detva,Stará Huta / Horný Tisovník,362,1,0.28%,287,1,0.35%
-Hlohovec,Trnavský,Piešťany,Veľké Orvište,1086,3,0.28%,,,
-Levice,Nitriansky,Nové Zámky,Bešeňov,1475,4,0.27%,,,
-Rožňava,Košický,Gelnica,Richnava,1477,4,0.27%,1477,0,0.00%
-Malacky,Bratislavský,Pezinok,Slovenský Grob,2592,7,0.27%,,,
-Zvolen,Banskobystrický,Žiar nad Hronom,Ihráč,371,1,0.27%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Veľká Čalomija + Malá Čalomija,373,1,0.27%,,,
-Michalovce,Košický,Michalovce,Lastomír,750,2,0.27%,719,1,0.14%
-Malacky,Bratislavský,Malacky,Marianka,1877,5,0.27%,,,
-Levice,Nitriansky,Nové Zámky,Bánov,2253,6,0.27%,,,
-Trenčín,Trenčiansky,Trenčín,Štvrtok,377,1,0.27%,369,2,0.54%
-Michalovce,Prešovský,Vranov nad Topľou,Jastrabie nad Topľou,377,1,0.27%,368,1,0.27%
-Nitra,Nitriansky,Nitra,Rumanová,758,2,0.26%,,,
-Zvolen,Banskobystrický,Lučenec,Radzovce,758,2,0.26%,,,
-Michalovce,Košický,Michalovce,Iňačovce,763,2,0.26%,756,0,0.00%
-Michalovce,Prešovský,Humenné,Kamienka,382,1,0.26%,369,0,0.00%
-Levice,Nitrianský,Komárno,Patince. Virt,765,2,0.26%,,,
-Michalovce,Prešovský,Vranov nad Topľou,Čičava,766,2,0.26%,731,0,0.00%
-Zvolen,Banskobystrický,Veľký Krtíš,Modrý Kameň,1150,3,0.26%,,,
-Zvolen,Banskobystrický,Banská Bystrica,Malachov,767,2,0.26%,777,2,0.26%
-Nitra,Nitriansky,Nitra,Čeľadice,767,2,0.26%,,,
-Sereď,Bratislavský,Senec,Most pri Bratislave,2693,7,0.26%,,,
-Levice,Nitriansky,Nové Zámky,Trávnica,770,2,0.26%,,,
-Bratislava,Bratislavský,Bratislava IV,Bratislava - Dúbravka,18890,49,0.26%,,,
-Trebišov,Košický,Košice - okolie,Perín - Chym,1158,3,0.26%,,,
-Trebišov,Košický,Trebišov,Sirník,389,1,0.26%,,,
-Levice,Nitrianský,Levice,Málaš,390,1,0.26%,,,
-Trebišov,Košický,Trebišov,Zemplínske Jastrabie,390,1,0.26%,,,
-Sereď,Bratislavský,Senec,Malinovo,2733,7,0.26%,,,
-Hlohovec,Trnavský,Trnava,Dolné Orešany,783,2,0.26%,,,
-Rožňava,Košický,Rimavská Sobota,Veľký Blh,786,2,0.25%,,,
-Trebišov,Košický,Trebišov,Nižný Žipov,787,2,0.25%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Záhorce + Selešťany,395,1,0.25%,,,
-Hlohovec,Trnavský,Trnava,Bučany,1980,5,0.25%,,,
-Trebišov,Košický,Košice - okolie,Turnianska Nová Ves,396,1,0.25%,,,
-Bratislava,Bratislavský,Bratislava III,Bratislava - Vajnory,4373,11,0.25%,,,
-Zvolen,Banskobystrický,Zvolen,Budča,1193,3,0.25%,1433,10,0.70%
-Žilina,Žilinský,Žilina,Malá Čierna,398,1,0.25%,325,0,0.00%
-Hlohovec,Trnavský,Hlohovec,Dvorníky,1208,3,0.25%,,,
-Zvolen,Banskobystrický,Lučenec,Biskupice,806,2,0.25%,,,
-Zvolen,Banskobystrický,Banská Štiavnica,Banský Studenec,403,1,0.25%,,,
-Hlohovec,Trnavský,Trnava,Šelpice,807,2,0.25%,,,
-Rožňava,Košický,Rimavská Sobota,Včelince,404,1,0.25%,,,
-Trebišov,Košický,Košice - okolie,Opátka,404,1,0.25%,,,
-Levice,Nitrianský,Levice,Mýtne Ludany. Starý Hrádok,811,2,0.25%,,,
-Michalovce,Prešovský,Snina,Topoľa,406,1,0.25%,334,1,0.30%
-Martin,Žilinský,Turčianske Teplice,Horná Štubňa,813,2,0.25%,869,3,0.35%
-Hlohovec,Trnavský,Trnava,Smolenice,3267,8,0.24%,,,
-Rožňava,Košický,Rožňava,Gemerská Poloma,1229,3,0.24%,,,
-Sereď,Trnavský,Galanta,Šintava,1230,3,0.24%,,,
-Michalovce,Košický,Michalovce,Lúčky,411,1,0.24%,424,0,0.00%
-Malacky,Bratislavský,Pezinok,Modra,6591,16,0.24%,,,
-Trebišov,Košický,Košice - okolie,Opiná,412,1,0.24%,,,
-Levice,Nitriansky,Nové Zámky,Obid,834,2,0.24%,,,
-Zvolen,Banskobystrický,Žiar nad Hronom,Prochot,420,1,0.24%,,,
-Sereď,Trnavský,Galanta,Kráľov Brod,841,2,0.24%,,,
-Rožňava,Košický,Rimavská Sobota,Ožďany,1263,3,0.24%,,,
-Sereď,Bratislavský,Senec,Tomášov,2527,6,0.24%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Kamenné Kosihy + Širákov + Ďurkovce + Seľany,423,1,0.24%,,,
-Rožňava,Košický,Rožňava,Čierna Lehota,426,1,0.23%,,,
-Levice,Nitrianský,Levice,Hronské Kľačany,854,2,0.23%,,,
-Trebišov,Košický,Košice - okolie,Košické Oľšany,856,2,0.23%,,,
-Michalovce,Košický,Michalovce,Suché,430,1,0.23%,342,2,0.58%
-Sereď,Trnavský,Galanta,Dolné Saliby,1721,4,0.23%,,,
-Sereď,Trnavský,Galanta,Veľká Mača,1732,4,0.23%,,,
-Nitra,Nitriansky,Nitra,Veľký Lapáš,874,2,0.23%,,,
-Michalovce,Košický,Michalovce,Staré,441,1,0.23%,452,1,0.22%
-Trebišov,Košický,Košice - okolie,Slanské Nové Mesto,442,1,0.23%,,,
-Rožňava,Košický,Rožňava,Dobšiná,2663,6,0.23%,,,
-Sereď,Trnavský,Dunajská Streda,Nový Život,1776,4,0.23%,2516,5,0.20%
-Bratislava,Bratislavský,Bratislava IV,Bratislava - Devín,1789,4,0.22%,,,
-Rožňava,Košický,Rimavská Sobota,Jesenské,1345,3,0.22%,,,
-Sereď,Trnavský,Galanta,Jánovce,449,1,0.22%,,,
-Trebišov,Košický,Košice - okolie,Bidovce,898,2,0.22%,,,
-Trebišov,Košický,Trebišov,Rad,450,1,0.22%,,,
-Martin,Žilinský,Turčianske Teplice,Sklené,452,1,0.22%,509,7,1.38%
-Trebišov,Košický,Košice II,Košice - Šaca,3175,7,0.22%,,,
-Michalovce,Košický,Michalovce,Oborín,454,1,0.22%,813,3,0.37%
-Trebišov,Košický,Košice - okolie,Seňa,1381,3,0.22%,,,
-Michalovce,Prešovský,Vranov nad Topľou,Slovenská Kajňa,462,1,0.22%,475,4,0.84%
-Zvolen,Banskobystrický,Žarnovica,Orovnica,462,1,0.22%,,,
-Levice,Nitrianský,Levice,Plášťovce,929,2,0.22%,,,
-Trebišov,Košický,Trebišov,Brezina,466,1,0.21%,,,
-Hlohovec,Trnavský,Trnava,Kátlovce,935,2,0.21%,,,
-Prešov,Prešovský,Bardejov,Kurov,468,1,0.21%,471,2,0.42%
-Michalovce,Košický,Sobrance,Tibava,468,1,0.21%,496,0,0.00%
-Hlohovec,Trnavský,Piešťany,Moravany nad Váhom,1414,3,0.21%,,,
-Michalovce,Košický,Michalovce,Tušice,474,1,0.21%,778,2,0.26%
-Trebišov,Košický,Trebišov,Veľký Kamenec,474,1,0.21%,,,
-Hlohovec,Trnavský,Piešťany,Krakovany,954,2,0.21%,,,
-Zvolen,Banskobystrický,Žiar nad Hronom,Dolná Ves,478,1,0.21%,,,
-Rožňava,Košický,Rimavská Sobota,Chanava,482,1,0.21%,,,
-Trebišov,Košický,Košice - okolie,Dvorníky - Včeláre,482,1,0.21%,,,
-Zvolen,Banskobystrický,Žiar nad Hronom,Prestavlky,482,1,0.21%,,,
-Levice,Nitrianský,Levice,Ondrejovce. Bajka,483,1,0.21%,,,
-Bratislava,Bratislavský,Bratislava V,Bratislava - Rusovce,2902,6,0.21%,,,
-Levice,Nitrianský,Levice,Nýrovce,489,1,0.20%,,,
-Hlohovec,Trnavský,Trnava,Horné Orešany,1470,3,0.20%,,,
-Trebišov,Košický,Trebišov,Bačkov,493,1,0.20%,,,
-Zvolen,Banskobystrický,Zvolen,Železná Breznica,496,1,0.20%,511,0,0.00%
-Trebišov,Košický,Trebišov,Nový Ruskov,498,1,0.20%,,,
-Rožňava,Košický,Poltár,Breznička,500,1,0.20%,,,
-Zvolen,Banskobystrický,Brezno,Lom nad Rimavicou,501,1,0.20%,,,
-Rožňava,Košický,Rimavská Sobota,Kociha,505,1,0.20%,,,
-Michalovce,Košický,Michalovce,Stretava,509,1,0.20%,502,0,0.00%
-Prešov,Prešovský,Prešov,Hrabkov,510,1,0.20%,494,1,0.20%
-Hlohovec,Trnavský,Piešťany,Nižná,513,1,0.19%,,,
-Michalovce,Košický,Sobrance,Porúbka,515,1,0.19%,527,0,0.00%
-Sereď,Bratislavský,Senec,Dunajská Lužná,4139,8,0.19%,,,
-Trebišov,Košický,Košice II,Košice - Myslava,1565,3,0.19%,,,
-Rožňava,Košický,Rožňava,Jovice,524,1,0.19%,,,
-Trebišov,Košický,Košice - okolie,Medzev,2103,4,0.19%,,,
-Trebišov,Košický,Košice II,Košice - Pereš,1058,2,0.19%,,,
-Martin,Žilinský,Turčianske Teplice,Slovenské Pravno,531,1,0.19%,542,4,0.74%
-Levice,Nitrianský,Komárno,Zeminská Olča,1599,3,0.19%,,,
-Michalovce,Košický,Michalovce,Trnava pri Laborci,534,1,0.19%,499,0,0.00%
-Rožňava,Košický,Rožňava,Krásnohorské Podhradie,1603,3,0.19%,,,
-Sereď,Trnavský,Galanta,Pusté Sady,535,1,0.19%,,,
-Michalovce,Košický,Michalovce,Horovce,538,1,0.19%,1129,8,0.71%
-Nitra,Nitriansky,Zlaté Moravce,Ladice,538,1,0.19%,,,
-Trebišov,Košický,Trebišov,Svätuše,539,1,0.19%,,,
-Bratislava,Bratislavský,Bratislava V,Bratislava - Čunovo,1623,3,0.18%,,,
-Trebišov,Košický,Trebišov,Zemplínske Hradište,542,1,0.18%,,,
-Trenčín,Trenčiansky,Myjava,Podkylava,547,1,0.18%,516,3,0.58%
-Ružomberok,Žilinský,Liptovský Mikuláš,Nižná Boca,551,1,0.18%,510,1,0.20%
-Levice,Nitrianský,Levice,Veľké Turovce,551,1,0.18%,,,
-Malacky,Bratislavský,Malacky,Malé Leváre,1655,3,0.18%,,,
-Trebišov,Košický,Košice - okolie,Bačkovík,553,1,0.18%,,,
-Trenčín,Trenčiansky,Myjava,Vrbovce,1109,2,0.18%,1042,3,0.29%
-Rožňava,Košický,Rimavská Sobota,Rimavská Seč,1114,2,0.18%,,,
-Rožňava,Košický,Revúca,Gemer,557,1,0.18%,,,
-Rožňava,Košický,Revúca,Revúca,5579,10,0.18%,,,
-Sereď,Trnavský,Dunajská Streda,Blahová,558,1,0.18%,485,2,0.41%
-Hlohovec,Trnavský,Piešťany,Dolný Lopašov,561,1,0.18%,,,
-Levice,Nitrianský,Levice,Vyškovce nad Ipľom,561,1,0.18%,,,
-Zvolen,Banskobystrický,Lučenec,Ružiná,561,1,0.18%,,,
-Rožňava,Košický,Revúca,Licince,564,1,0.18%,,,
-Sereď,Trnavský,Galanta,Malá Mača,565,1,0.18%,,,
-Rožňava,Košický,Rožňava,Rožňava,7940,14,0.18%,,,
-Rožňava,Košický,Rožňava,Čučma,569,1,0.18%,,,
-Nitra,Nitriansky,Zlaté Moravce,Beladice,1142,2,0.18%,,,
-Zvolen,Banskobystrický,Žarnovica,Horné Hámre,571,1,0.18%,,,
-Levice,Nitriansky,Nové Zámky,Rúbaň,577,1,0.17%,,,
-Zvolen,Banskobystrický,Žiar nad Hronom,Janova Lehota,577,1,0.17%,,,
-Prešov,Prešovský,Prešov,Šindliar,578,1,0.17%,523,1,0.19%
-Trebišov,Košický,Košice - okolie,Vyšný Medzev,581,1,0.17%,,,
-Sereď,Bratislavský,Senec,Vlky,584,1,0.17%,,,
-Levice,Nitrianský,Levice,Pastovce. Bielovce,586,1,0.17%,,,
-Malacky,Bratislavský,Malacky,Jablonové,1181,2,0.17%,,,
-Hlohovec,Trnavský,Trnava,Bíňovce,594,1,0.17%,,,
-Levice,Nitrianský,Levice,Nový Tekov,608,1,0.16%,,,
-Zvolen,Banskobystrický,Zvolen,Tŕnie a Natúrovej,609,1,0.16%,388,0,0.00%
-Rožňava,Košický,Poltár,Hrnčiarske Zalužany,611,1,0.16%,,,
-Zvolen,Banskobystrický,Žarnovica,Hronský Beňadik,612,1,0.16%,,,
-Levice,Nitrianský,Levice,Sikenica,619,1,0.16%,,,
-Nitra,Nitriansky,Zlaté Moravce,Velčice,620,1,0.16%,,,
-Trebišov,Košický,Košice - okolie,Veľká Ida,2501,4,0.16%,,,
-Levice,Nitrianský,Levice,Hronské Kosihy,626,1,0.16%,,,
-Trebišov,Košický,Košice IV,Košice - Šebastovce,627,1,0.16%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Čebovce,628,1,0.16%,,,
-Levice,Nitriansky,Nové Zámky,Nová Vieska,643,1,0.16%,,,
-Hlohovec,Trnavský,Trnava,Buková,646,1,0.15%,,,
-Rožňava,Košický,Rožňava,Brzotín,648,1,0.15%,,,
-Rožňava,Košický,Rožňava,Štítnik,657,1,0.15%,,,
-Trebišov,Košický,Trebišov,Borša,659,1,0.15%,,,
-Trebišov,Košický,Košice - okolie,Drienovec,1319,2,0.15%,,,
-Levice,Nitrianský,Levice,Krškany,666,1,0.15%,,,
-Zvolen,Banskobystrický,Zvolen,Pliešovce Zaježova,667,1,0.15%,,,
-Trebišov,Košický,Trebišov,Zemplínska Nová Ves,673,1,0.15%,,,
-Sereď,Trnavský,Galanta,Jelka,3368,5,0.15%,,,
-Levice,Nitrianský,Levice,Demandice,691,1,0.14%,,,
-Zvolen,Banskobystrický,Lučenec,Fiľakovské Kováče,700,1,0.14%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Sklabiná,701,1,0.14%,,,
-Sereď,Trnavský,Galanta,Gáň,710,1,0.14%,,,
-Levice,Nitrianský,Komárno,Čalovec,714,1,0.14%,,,
-Rožňava,Košický,Poltár,Málinec,722,1,0.14%,,,
-Malacky,Bratislavský,Malacky,Plavecké Podhradie,726,1,0.14%,,,
-Michalovce,Košický,Michalovce,Pozdišovce,736,1,0.14%,807,5,0.62%
-Trebišov,Košický,Košice IV,Košice - Vyšné Opátske,1472,2,0.14%,,,
-Trebišov,Košický,Trebišov,Veľké Trakany,767,1,0.13%,,,
-Trebišov,Košický,Košice III,Košice - Košická Nová Ves,1541,2,0.13%,,,
-Michalovce,Košický,Michalovce,Vojany,805,1,0.12%,772,1,0.13%
-Zvolen,Banskobystrický,Zvolen,Očová,1652,2,0.12%,1688,6,0.36%
-Levice,Nitriansky,Nové Zámky,Komjatice,2493,3,0.12%,,,
-Nitra,Nitriansky,Nitra,Báb,845,1,0.12%,,,
-Levice,Nitrianský,Komárno,Bajč,858,1,0.12%,,,
-Sereď,Trnavský,Galanta,Mostová,860,1,0.12%,,,
-Malacky,Trnavský,Senica,Lakšárska Nová Ves,867,1,0.12%,1167,3,0.26%
-Trebišov,Košický,Košice - okolie,Kecerovce,1752,2,0.11%,,,
-Rožňava,Košický,Rožňava,Slavošovce,884,1,0.11%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Vinica,911,1,0.11%,,,
-Sereď,Trnavský,Galanta,Dolná Streda,927,1,0.11%,,,
-Nitra,Nitriansky,Nitra,Mojmírovce,1901,2,0.11%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Bušince + Muľa,958,1,0.10%,,,
-Sereď,Trnavský,Dunajská Streda,Jahodná,984,1,0.10%,1915,4,0.21%
-Nitra,Nitriansky,Nitra,Veľký Cetín,1007,1,0.10%,,,
-Levice,Nitrianský,Levice,Bátovce. Bohunice. Pečenice,1057,1,0.09%,,,
-Trebišov,Košický,Košice - okolie,Kysak,1180,1,0.08%,,,
-Zvolen,Banskobystrický,Zvolen,Dobrá Niva,1244,1,0.08%,1873,2,0.11%
-Levice,Nitriansky,Nové Zámky,Kamenica n/Hronom,1271,1,0.08%,,,
-Hlohovec,Trnavský,Piešťany,Veľké Kostoľany,1388,1,0.07%,,,
-Levice,Nitriansky,Nové Zámky,Svodín,1488,1,0.07%,,,
-Prešov,Prešovský,Svidník,Jurkova Voľa,50,0,0.00%,49,2,4.08%
-Prešov,Prešovský,Svidník,Pstriná,82,0,0.00%,76,3,3.95%
-Prešov,Prešovský,Stropkov,Vojtovce,137,0,0.00%,59,2,3.39%
-Prešov,Prešovský,Stará Ľubovňa,Lacková,144,0,0.00%,154,4,2.60%
-Prešov,Prešovský,Bardejov,Lipová,103,0,0.00%,81,2,2.47%
-Prešov,Prešovský,Levoča,Lúčka,47,0,0.00%,43,1,2.33%
-Prešov,Prešovský,Stará Ľubovňa,Kremná,0,0,0.00%,91,2,2.20%
-Žilina,Žilinský,Žilina,Veľká Čierna,212,0,0.00%,216,4,1.85%
-Prešov,Prešovský,Svidník,Fijaš,173,0,0.00%,169,3,1.78%
-Zvolen,Banskobystrický,Zvolen,Hronská Breznica,153,0,0.00%,341,6,1.76%
-Trenčín,Trenčiansky,Považská Bystrica,Sádočné,113,0,0.00%,115,2,1.74%
-Prešov,Prešovský,Svidník,Nová Polianka,94,0,0.00%,118,2,1.69%
-Prešov,Prešovský,Levoča,Vyšné Repaše,124,0,0.00%,125,2,1.60%
-Prešov,Prešovský,Svidník,Dubová,80,0,0.00%,126,2,1.59%
-Prešov,Prešovský,Stropkov,Korunková,60,0,0.00%,63,1,1.59%
-Prešov,Prešovský,Stropkov,Miňovce,200,0,0.00%,208,3,1.44%
-Topoľčany,Trenčiansky,Prievidza,Chvojnica,179,0,0.00%,216,3,1.39%
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Višňové,137,0,0.00%,150,2,1.33%
-Trenčín,Trenčiansky,Považská Bystrica,Vrchteplá,155,0,0.00%,151,2,1.32%
-Prešov,Prešovský,Bardejov,Vyšný Kručov,129,0,0.00%,155,2,1.29%
-Sereď,Trnavský,Dunajská Streda,Vojka nad Dunajom,362,0,0.00%,699,7,1.00%
-Malacky,Trnavský,Senica,Osuské,496,0,0.00%,543,5,0.92%
-Prešov,Prešovský,Prešov,Seniakovce,134,0,0.00%,559,5,0.89%
-Trenčín,Trenčiansky,Považská Bystrica,Podskalie,1005,0,0.00%,117,1,0.85%
-Trenčín,Trenčiansky,Myjava,Polianka,349,0,0.00%,357,3,0.84%
-Rožňava,Košický,Gelnica,Smolník,592,0,0.00%,739,6,0.81%
-Prešov,Prešovský,Prešov,Ľubovec,428,0,0.00%,391,3,0.77%
-Prešov,Prešovský,Prešov,Chminianske Jakubovany,1042,0,0.00%,1027,7,0.68%
-Zvolen,Banskobystrický,Zvolen,Babiná,160,0,0.00%,446,3,0.67%
-Rožňava,Košický,Spišská Nová Ves,Oľšavka,131,0,0.00%,151,1,0.66%
-Prešov,Prešovský,Stropkov,Duplín,160,0,0.00%,157,1,0.64%
-Michalovce,Košický,Michalovce,Poruba pod Vihorlatom,493,0,0.00%,472,3,0.64%
-Trenčín,Trenčiansky,Trenčín,Adamovské Kochanovce,640,0,0.00%,645,4,0.62%
-Michalovce,Košický,Michalovce,Lesné,356,0,0.00%,330,2,0.61%
-Michalovce,Košický,Sobrance,Veľké Revištia,339,0,0.00%,352,2,0.57%
-Prešov,Prešovský,Svidník,Lužany pri Topli,198,0,0.00%,193,1,0.52%
-Michalovce,Košický,Michalovce,Krišovská Liesková,614,0,0.00%,589,3,0.51%
-Žilina,Žilinský,Žilina,Nededza,0,0,0.00%,1058,5,0.47%
-Prešov,Prešovský,Stropkov,Bukovce,202,0,0.00%,220,1,0.45%
-Sereď,Trnavský,Dunajská Streda,Čenkovce,891,0,0.00%,1344,6,0.45%
-Prešov,Prešovský,Prešov,Proč,231,0,0.00%,239,1,0.42%
-Zvolen,Banskobystrický,Detva,Vígľaská Huta - Kalinka,190,0,0.00%,250,1,0.40%
-Topoľčany,Trenčiansky,Prievidza,Seč,226,0,0.00%,253,1,0.40%
-Topoľčany,Trenčiansky,Prievidza,Nevidzany,303,0,0.00%,278,1,0.36%
-Malacky,Trnavský,Skalica,Trnovec,181,0,0.00%,291,1,0.34%
-Sereď,Trnavský,Dunajská Streda,Kyselica,113,0,0.00%,295,1,0.34%
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Nová Ves nad Váhom,278,0,0.00%,308,1,0.32%
-Zvolen,Banskobystrický,Zvolen,Pliešovce,495,0,0.00%,1546,5,0.32%
-Topoľčany,Nitriansky,Topoľčany,Orešany,315,0,0.00%,312,1,0.32%
-Michalovce,Košický,Sobrance,Blatné Remety,306,0,0.00%,313,1,0.32%
-Malacky,Trnavský,Senica,Jablonica,1609,0,0.00%,2316,7,0.30%
-Michalovce,Košický,Michalovce,Oreské,319,0,0.00%,341,1,0.29%
-Michalovce,Košický,Michalovce,Čierne Pole,422,0,0.00%,404,1,0.25%
-Michalovce,Košický,Michalovce,Krásnovce,448,0,0.00%,481,1,0.21%
-Sereď,Trnavský,Dunajská Streda,Bodíky,715,0,0.00%,632,1,0.16%
-Martin,Žilinský,Turčianske Teplice,Brieštie,161,0,0.00%,169,0,0.00%
-Martin,Žilinský,Turčianske Teplice,Veľký Čepčín,393,0,0.00%,206,0,0.00%
-Ružomberok,Žilinský,Liptovský Mikuláš,Demänovská Dolina,114,0,0.00%,172,0,0.00%
-Ružomberok,Žilinský,Liptovský Mikuláš,Malé Borové,72,0,0.00%,92,0,0.00%
-Malacky,Trnavský,Skalica,Letničie,489,0,0.00%,423,0,0.00%
-Trenčín,Trenčiansky,Trenčín,Krivosúd - Bodovka,217,0,0.00%,232,0,0.00%
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Hrádok,642,0,0.00%,756,0,0.00%
-Trenčín,Trenčiansky,Nové Mesto nad Váhom,Stará Lehota,143,0,0.00%,169,0,0.00%
-Trenčín,Trenčiansky,Myjava,Bukovec,388,0,0.00%,382,0,0.00%
-Trenčín,Trenčiansky,Myjava,Hrašné,267,0,0.00%,276,0,0.00%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Cimenná,74,0,0.00%,83,0,0.00%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Omastiná,10,0,0.00%,30,0,0.00%
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Žitná - Radiša,29,0,0.00%,74,0,0.00%
-Michalovce,Prešovský,Vranov nad Topľou,Cabov,353,0,0.00%,513,0,0.00%
-Michalovce,Prešovský,Vranov nad Topľou,Čierne nad Topľou,457,0,0.00%,498,0,0.00%
-Michalovce,Prešovský,Vranov nad Topľou,Nová Kelča,292,0,0.00%,292,0,0.00%
-Prešov,Prešovský,Svidník,Belejovce,59,0,0.00%,10,0,0.00%
-Prešov,Prešovský,Svidník,Bodružal,48,0,0.00%,81,0,0.00%
-Prešov,Prešovský,Svidník,Dlhoňa,61,0,0.00%,62,0,0.00%
-Prešov,Prešovský,Svidník,Dobroslava,32,0,0.00%,34,0,0.00%
-Prešov,Prešovský,Svidník,Havranec,14,0,0.00%,14,0,0.00%
-Prešov,Prešovský,Svidník,Hrabovčík,148,0,0.00%,140,0,0.00%
-Prešov,Prešovský,Svidník,Korejovce,63,0,0.00%,57,0,0.00%
-Prešov,Prešovský,Svidník,Medvedie,11,0,0.00%,29,0,0.00%
-Prešov,Prešovský,Svidník,Miroľa,35,0,0.00%,31,0,0.00%
-Prešov,Prešovský,Svidník,Mlynárovce,42,0,0.00%,94,0,0.00%
-Prešov,Prešovský,Svidník,Nižná Jedľová,113,0,0.00%,115,0,0.00%
-Prešov,Prešovský,Svidník,Príkra,8,0,0.00%,26,0,0.00%
-Prešov,Prešovský,Svidník,Rakovčík,78,0,0.00%,70,0,0.00%
-Prešov,Prešovský,Svidník,Svidnička,49,0,0.00%,73,0,0.00%
-Prešov,Prešovský,Svidník,Šarbov,34,0,0.00%,27,0,0.00%
-Prešov,Prešovský,Svidník,Šemetkovce,110,0,0.00%,94,0,0.00%
-Prešov,Prešovský,Svidník,Štefurov,83,0,0.00%,89,0,0.00%
-Prešov,Prešovský,Svidník,Vagrinec,78,0,0.00%,83,0,0.00%
-Prešov,Prešovský,Svidník,Vápeník,81,0,0.00%,74,0,0.00%
-Prešov,Prešovský,Svidník,Vyšná Pisaná,78,0,0.00%,66,0,0.00%
-Prešov,Prešovský,Svidník,Vyšný Komárnik,44,0,0.00%,40,0,0.00%
-Prešov,Prešovský,Svidník,Železník,189,0,0.00%,208,0,0.00%
-Prešov,Prešovský,Stropkov,Kolbovce,155,0,0.00%,163,0,0.00%
-Prešov,Prešovský,Stropkov,Kožuchovce,43,0,0.00%,47,0,0.00%
-Prešov,Prešovský,Stropkov,Krišľovce,23,0,0.00%,31,0,0.00%
-Prešov,Prešovský,Stropkov,Krušinec,93,0,0.00%,118,0,0.00%
-Prešov,Prešovský,Stropkov,Makovce,111,0,0.00%,116,0,0.00%
-Prešov,Prešovský,Stropkov,Miková,79,0,0.00%,90,0,0.00%
-Prešov,Prešovský,Stropkov,Potôčky,103,0,0.00%,84,0,0.00%
-Prešov,Prešovský,Stropkov,Soľník,29,0,0.00%,33,0,0.00%
-Prešov,Prešovský,Stropkov,Tokajík,109,0,0.00%,97,0,0.00%
-Prešov,Prešovský,Stropkov,Turany nad Ondavou,198,0,0.00%,202,0,0.00%
-Prešov,Prešovský,Stropkov,Vislava,111,0,0.00%,126,0,0.00%
-Prešov,Prešovský,Stropkov,Vyšný Hrabovec,124,0,0.00%,102,0,0.00%
-Prešov,Prešovský,Stará Ľubovňa,Hajtovka,28,0,0.00%,35,0,0.00%
-Prešov,Prešovský,Prešov,Mošurov,106,0,0.00%,169,0,0.00%
-Prešov,Prešovský,Prešov,Nemcovce,298,0,0.00%,281,0,0.00%
-Prešov,Prešovský,Prešov,Ondrašovce,147,0,0.00%,231,0,0.00%
-Prešov,Prešovský,Prešov,Šarišská Trstená,209,0,0.00%,221,0,0.00%
-Prešov,Prešovský,Prešov,Štefanovce,299,0,0.00%,221,0,0.00%
-Michalovce,Prešovský,Medzilaborce,Oľka,119,0,0.00%,192,0,0.00%
-Prešov,Prešovský,Levoča,Brutovce,82,0,0.00%,92,0,0.00%
-Prešov,Prešovský,Levoča,Oľšavica,128,0,0.00%,133,0,0.00%
-Prešov,Prešovský,Bardejov,Bogliarka,71,0,0.00%,86,0,0.00%
-Prešov,Prešovský,Bardejov,Hutka,85,0,0.00%,64,0,0.00%
-Prešov,Prešovský,Bardejov,Chmeľová,276,0,0.00%,343,0,0.00%
-Prešov,Prešovský,Bardejov,Nižná Polianka,177,0,0.00%,186,0,0.00%
-Prešov,Prešovský,Bardejov,Stebnícka Huta,97,0,0.00%,95,0,0.00%
-Prešov,Prešovský,Bardejov,Varadka,143,0,0.00%,99,0,0.00%
-Prešov,Prešovský,Bardejov,Vyšný Tvarožec,76,0,0.00%,82,0,0.00%
-Rožňava,Košický,Spišská Nová Ves,Kaľava,182,0,0.00%,187,0,0.00%
-Rožňava,Košický,Spišská Nová Ves,Matejovce nad Hornádom,308,0,0.00%,322,0,0.00%
-Michalovce,Košický,Sobrance,Blatné Revištia,190,0,0.00%,199,0,0.00%
-Michalovce,Košický,Sobrance,Remetské Hámre,557,0,0.00%,570,0,0.00%
-Michalovce,Košický,Sobrance,Ruský Hrabovec,261,0,0.00%,285,0,0.00%
-Michalovce,Košický,Michalovce,Falkušovce,365,0,0.00%,391,0,0.00%
-Michalovce,Košický,Michalovce,Kaluža,449,0,0.00%,463,0,0.00%
-Michalovce,Košický,Michalovce,Žbince,563,0,0.00%,567,0,0.00%
-Rožňava,Košický,Gelnica,Úhorná,113,0,0.00%,180,0,0.00%
-Zvolen,Banskobystrický,Zvolen,Bzovská Lehôtka,91,0,0.00%,124,0,0.00%
-Zvolen,Banskobystrický,Zvolen,Dubové. Breziny. Michalková,152,0,0.00%,235,0,0.00%
-Zvolen,Banskobystrický,Brezno,Ráztoka,337,0,0.00%,312,0,0.00%
-Zvolen,Banskobystrický,Banská Bystrica,Dolný Harmanec,163,0,0.00%,228,0,0.00%
-Zvolen,Banskobystrický,Banská Bystrica,Povrazník,173,0,0.00%,193,0,0.00%
-Sereď,Trnavský,Dunajská Streda,Bellova Ves,221,0,0.00%,309,0,0.00%
-Hlohovec,Trnavský,Trnava,Slovenská Nová Ves,265,0,0.00%,,,
-Hlohovec,Trnavský,Piešťany,Kočín - Lančár,577,0,0.00%,,,
-Hlohovec,Trnavský,Piešťany,Prašník,770,0,0.00%,,,
-Hlohovec,Trnavský,Piešťany,Šterusy,269,0,0.00%,,,
-Hlohovec,Trnavský,Hlohovec,Dolné Zelenice,485,0,0.00%,,,
-Sereď,Trnavský,Galanta,Dolný Chotár,209,0,0.00%,,,
-Sereď,Trnavský,Galanta,Hoste,305,0,0.00%,,,
-Sereď,Trnavský,Galanta,Vozokany,814,0,0.00%,,,
-Sereď,Trnavský,Galanta,Zemianske Sady,538,0,0.00%,,,
-Trenčín,Trenčiansky,Bánovce nad Bebravou,Trebichava,0,0,0.00%,,,
-Prešov,Prešovský,Stropkov,Bystrá,0,0,0.00%,,,
-Prešov,Prešovský,Stropkov,Mrázovce,0,0,0.00%,,,
-Prešov,Prešovský,Levoča,Pongrácovce,145,0,0.00%,,,
-Prešov,Prešovský,Kežmarok,Havka,0,0,0.00%,,,
-Prešov,Prešovský,Bardejov,Ondavka,175,0,0.00%,,,
-Levice,Nitrianský,Levice,Čata,686,0,0.00%,,,
-Levice,Nitrianský,Levice,Dolné Semerovce,204,0,0.00%,,,
-Levice,Nitrianský,Levice,Hokovce,385,0,0.00%,,,
-Levice,Nitrianský,Levice,Iňa. Jesenské,404,0,0.00%,,,
-Levice,Nitrianský,Levice,Ipeľský Sokolec,513,0,0.00%,,,
-Levice,Nitrianský,Levice,Jabloňovce,168,0,0.00%,,,
-Levice,Nitrianský,Levice,Kukučínov,427,0,0.00%,,,
-Levice,Nitrianský,Levice,Lontov,437,0,0.00%,,,
-Levice,Nitrianský,Levice,Sazdice. Kubáňovo,311,0,0.00%,,,
-Levice,Nitrianský,Komárno,Bodzianské Lúky,484,0,0.00%,,,
-Levice,Nitrianský,Komárno,Dedina Mládeže,315,0,0.00%,,,
-Levice,Nitrianský,Komárno,Šrobárová,290,0,0.00%,,,
-Nitra,Nitriansky,Zlaté Moravce,Malé Vozokany,185,0,0.00%,,,
-Nitra,Nitriansky,Zlaté Moravce,Obyce,991,0,0.00%,,,
-Nitra,Nitriansky,Zlaté Moravce,Vieska,214,0,0.00%,,,
-Nitra,Nitriansky,Zlaté Moravce,Volkovce,546,0,0.00%,,,
-Levice,Nitriansky,Nové Zámky,Bajtava,243,0,0.00%,,,
-Levice,Nitriansky,Nové Zámky,Čechy,206,0,0.00%,,,
-Levice,Nitriansky,Nové Zámky,Černík,811,0,0.00%,,,
-Levice,Nitriansky,Nové Zámky,Leľa,169,0,0.00%,,,
-Levice,Nitriansky,Nové Zámky,Šarkan,216,0,0.00%,,,
-Nitra,Nitriansky,Nitra,Bádice,536,0,0.00%,,,
-Nitra,Nitriansky,Nitra,Hosťová,261,0,0.00%,,,
-Nitra,Nitriansky,Nitra,Malé Chyndice,463,0,0.00%,,,
-Nitra,Nitriansky,Nitra,Paňa,269,0,0.00%,,,
-Nitra,Nitriansky,Nitra,Zlatno,124,0,0.00%,,,
-Trebišov,Košický,Trebišov,Bara,120,0,0.00%,,,
-Trebišov,Košický,Trebišov,Byšta,85,0,0.00%,,,
-Trebišov,Košický,Trebišov,Cejkov,634,0,0.00%,,,
-Trebišov,Košický,Trebišov,Černochov,248,0,0.00%,,,
-Trebišov,Košický,Trebišov,Čierna,182,0,0.00%,,,
-Trebišov,Košický,Trebišov,Dvorianky,323,0,0.00%,,,
-Trebišov,Košický,Trebišov,Kašov,121,0,0.00%,,,
-Trebišov,Košický,Trebišov,Kožuchov,226,0,0.00%,,,
-Trebišov,Košický,Trebišov,Luhyňa,289,0,0.00%,,,
-Trebišov,Košický,Trebišov,Malý Horeš,750,0,0.00%,,,
-Trebišov,Košický,Trebišov,Poľany,191,0,0.00%,,,
-Trebišov,Košický,Trebišov,Soľnička,220,0,0.00%,,,
-Trebišov,Košický,Trebišov,Stankovce,218,0,0.00%,,,
-Trebišov,Košický,Trebišov,Svätá Mária,351,0,0.00%,,,
-Trebišov,Košický,Trebišov,Svinice,306,0,0.00%,,,
-Trebišov,Košický,Trebišov,Trnávka,186,0,0.00%,,,
-Trebišov,Košický,Trebišov,Veľaty,459,0,0.00%,,,
-Trebišov,Košický,Trebišov,Višňov,81,0,0.00%,,,
-Trebišov,Košický,Trebišov,Vojka,322,0,0.00%,,,
-Trebišov,Košický,Trebišov,Zbehňov,193,0,0.00%,,,
-Rožňava,Košický,Rožňava,Betliar,546,0,0.00%,,,
-Rožňava,Košický,Rožňava,Bohúňovo,144,0,0.00%,,,
-Rožňava,Košický,Rožňava,Bôrka,338,0,0.00%,,,
-Rožňava,Košický,Rožňava,Brdárka,100,0,0.00%,,,
-Rožňava,Košický,Rožňava,Čoltovo,134,0,0.00%,,,
-Rožňava,Košický,Rožňava,Drnava,491,0,0.00%,,,
-Rožňava,Košický,Rožňava,Gemerská Hôrka,815,0,0.00%,,,
-Rožňava,Košický,Rožňava,Gočaltovo,302,0,0.00%,,,
-Rožňava,Košický,Rožňava,Gočovo,200,0,0.00%,,,
-Rožňava,Košický,Rožňava,Hanková,134,0,0.00%,,,
-Rožňava,Košický,Rožňava,Kečovo,218,0,0.00%,,,
-Rožňava,Košický,Rožňava,Koceľovce,130,0,0.00%,,,
-Rožňava,Košický,Rožňava,Krásnohorská Dlhá Lúka,499,0,0.00%,,,
-Rožňava,Košický,Rožňava,Kružná,304,0,0.00%,,,
-Rožňava,Košický,Rožňava,Kunova Teplica,423,0,0.00%,,,
-Rožňava,Košický,Rožňava,Lipovník,390,0,0.00%,,,
-Rožňava,Košický,Rožňava,Lúčka,194,0,0.00%,,,
-Rožňava,Košický,Rožňava,Markuška,266,0,0.00%,,,
-Rožňava,Košický,Rožňava,Ochtiná,359,0,0.00%,,,
-Rožňava,Košický,Rožňava,Pašková,209,0,0.00%,,,
-Rožňava,Košický,Rožňava,Petrovo,65,0,0.00%,,,
-Rožňava,Košický,Rožňava,Plešivec,1100,0,0.00%,,,
-Rožňava,Košický,Rožňava,Rochovce,185,0,0.00%,,,
-Rožňava,Košický,Rožňava,Rozložná,127,0,0.00%,,,
-Rožňava,Košický,Rožňava,Silica,307,0,0.00%,,,
-Rožňava,Košický,Rožňava,Silická Brezová,86,0,0.00%,,,
-Rožňava,Košický,Rožňava,Silická Jablonica,139,0,0.00%,,,
-Rožňava,Košický,Rožňava,Slavec. Vidová,270,0,0.00%,,,
-Rožňava,Košický,Rožňava,Stratená,115,0,0.00%,,,
-Rožňava,Košický,Rožňava,Vyšná Slaná,250,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Babinec,0,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Barca,281,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Belín,113,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Bottovo,145,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Cakov,21,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Číž,408,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Drienčany,0,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Drňa,190,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Dubno,104,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Dubovec,271,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Dulovo,220,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Figa,246,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Gemerček,99,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Gemerské Michalovce,175,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Hodejovec,127,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Horné Zahorany,105,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Hostice,615,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Hrušovo,24,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Chrámec,139,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Janice,257,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Jestice,104,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Kaloša,437,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Kesovce,50,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Konrádovce,0,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Krokava,0,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Lenartovce,348,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Lipovec,52,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Martinová,334,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Neporadza,154,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Padarovce,31,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Pavlovce,498,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Petrovce,117,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Poproč,91,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Potok,1,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Radnovce,722,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Rakytník,203,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Ratkovská Lehota,126,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Riečka,352,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Rimavská Baňa,460,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Rimavské Brezovo,230,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Rimavské Janovce,722,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Rovné,116,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Rumince,232,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Slizké,55,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Studená,239,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Sútor,259,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Šimonovce,270,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Širkovce,436,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Španie Pole,160,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Štrkovec,193,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Uzovská Panica,254,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Valice,188,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Vyšné Valice,149,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Zádor,0,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Zacharovce,156,0,0.00%,,,
-Rožňava,Košický,Rimavská Sobota,Žíp,189,0,0.00%,,,
-Rožňava,Košický,Revúca,Gemerské Teplice,435,0,0.00%,,,
-Rožňava,Košický,Revúca,Gemerský Sad,190,0,0.00%,,,
-Rožňava,Košický,Revúca,Hucín,528,0,0.00%,,,
-Rožňava,Košický,Revúca,Chyžné,228,0,0.00%,,,
-Rožňava,Košický,Revúca,Kameňany,512,0,0.00%,,,
-Rožňava,Košický,Revúca,Magnezitovce,317,0,0.00%,,,
-Rožňava,Košický,Revúca,Mokrá Lúka,480,0,0.00%,,,
-Rožňava,Košický,Revúca,Muráň,764,0,0.00%,,,
-Rožňava,Košický,Revúca,Muránska Lehota,224,0,0.00%,,,
-Rožňava,Košický,Revúca,Muránska Zdychava,178,0,0.00%,,,
-Rožňava,Košický,Revúca,Nandraž,167,0,0.00%,,,
-Rožňava,Košický,Revúca,Ploské,0,0,0.00%,,,
-Rožňava,Košický,Revúca,Rákoš,223,0,0.00%,,,
-Rožňava,Košický,Revúca,Rašice,276,0,0.00%,,,
-Rožňava,Košický,Revúca,Ratkovské Bystré,277,0,0.00%,,,
-Rožňava,Košický,Revúca,Revúcka Lehota,265,0,0.00%,,,
-Rožňava,Košický,Revúca,Rybník,61,0,0.00%,,,
-Rožňava,Košický,Revúca,Sása,132,0,0.00%,,,
-Rožňava,Košický,Revúca,Sirk,594,0,0.00%,,,
-Rožňava,Košický,Revúca,Skerešovo,111,0,0.00%,,,
-Rožňava,Košický,Revúca,Šivetice,122,0,0.00%,,,
-Rožňava,Košický,Revúca,Turčok,156,0,0.00%,,,
-Rožňava,Košický,Revúca,Žiar,95,0,0.00%,,,
-Rožňava,Košický,Poltár,Ďubákovo,59,0,0.00%,,,
-Rožňava,Košický,Poltár,Krná,46,0,0.00%,,,
-Rožňava,Košický,Poltár,Mládzovo,66,0,0.00%,,,
-Rožňava,Košický,Poltár,Rovňany,135,0,0.00%,,,
-Rožňava,Košický,Poltár,Utekáč,608,0,0.00%,,,
-Trebišov,Košický,Košice - okolie,Belža,217,0,0.00%,,,
-Trebišov,Košický,Košice - okolie,Bunetice,246,0,0.00%,,,
-Trebišov,Košický,Košice - okolie,Hodkovce,197,0,0.00%,,,
-Trebišov,Košický,Košice - okolie,Hýľov,300,0,0.00%,,,
-Trebišov,Košický,Košice - okolie,Janík,678,0,0.00%,,,
-Trebišov,Košický,Košice - okolie,Komárovce,246,0,0.00%,,,
-Trebišov,Košický,Košice - okolie,Košický Klečenov,168,0,0.00%,,,
-Trebišov,Košický,Košice - okolie,Malá Ida,1163,0,0.00%,,,
-Trebišov,Košický,Košice - okolie,Malá Lodina +Veľká Lodina,352,0,0.00%,,,
-Trebišov,Košický,Košice - okolie,Nižná Myšľa,1002,0,0.00%,,,
-Trebišov,Košický,Košice - okolie,Nováčany,610,0,0.00%,,,
-Trebišov,Košický,Košice - okolie,Nový Salaš,182,0,0.00%,,,
-Trebišov,Košický,Košice - okolie,Rákoš,339,0,0.00%,,,
-Trebišov,Košický,Košice - okolie,Rešica,355,0,0.00%,,,
-Trebišov,Košický,Košice - okolie,Trebejov,402,0,0.00%,,,
-Trebišov,Košický,Košice - okolie,Trsťany,381,0,0.00%,,,
-Trebišov,Košický,Košice - okolie,Vajkovce,755,0,0.00%,,,
-Trebišov,Košický,Košice - okolie,Vyšný Klátov,487,0,0.00%,,,
-Sereď,Bratislavský,Senec,Igram,328,0,0.00%,,,
-Malacky,Bratislavský,Pezinok,Doľany,906,0,0.00%,,,
-Malacky,Bratislavský,Pezinok,Štefanová,188,0,0.00%,,,
-Malacky,Bratislavský,Malacky,Pernek,772,0,0.00%,,,
-Zvolen,Banskobystrický,Žiar nad Hronom,Bartošova Lehôtka,321,0,0.00%,,,
-Zvolen,Banskobystrický,Žiar nad Hronom,Horná Ves,112,0,0.00%,,,
-Zvolen,Banskobystrický,Žiar nad Hronom,Horná Ždaňa,405,0,0.00%,,,
-Zvolen,Banskobystrický,Žiar nad Hronom,Jastrabá,255,0,0.00%,,,
-Zvolen,Banskobystrický,Žiar nad Hronom,Kopernica,207,0,0.00%,,,
-Zvolen,Banskobystrický,Žiar nad Hronom,Kosorín,344,0,0.00%,,,
-Zvolen,Banskobystrický,Žiar nad Hronom,Krahule,334,0,0.00%,,,
-Zvolen,Banskobystrický,Žiar nad Hronom,Lovča,202,0,0.00%,,,
-Zvolen,Banskobystrický,Žiar nad Hronom,Lúčky,231,0,0.00%,,,
-Zvolen,Banskobystrický,Žiar nad Hronom,Nevoľné,201,0,0.00%,,,
-Zvolen,Banskobystrický,Žiar nad Hronom,Slaská,315,0,0.00%,,,
-Zvolen,Banskobystrický,Žiar nad Hronom,Vyhne,659,0,0.00%,,,
-Zvolen,Banskobystrický,Žarnovica,Brehy,639,0,0.00%,,,
-Zvolen,Banskobystrický,Žarnovica,Hronský Beňadik - Psiare,159,0,0.00%,,,
-Zvolen,Banskobystrický,Žarnovica,Píla,75,0,0.00%,,,
-Zvolen,Banskobystrický,Žarnovica,Veľké Pole,319,0,0.00%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Čeláre,250,0,0.00%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Čelovce,372,0,0.00%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Dačov Lom,268,0,0.00%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Horné Plachtince,355,0,0.00%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Hrušov,538,0,0.00%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Kleňany,209,0,0.00%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Kováčovce,279,0,0.00%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Malý Krtíš,536,0,0.00%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Obeckov + Nová Ves,245,0,0.00%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Pôtor,417,0,0.00%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Pôtor - Žihľava,140,0,0.00%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Príbelce,362,0,0.00%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Senné + Brusník + Šuľa + Červeňany,229,0,0.00%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Slovenské Kľačany + Vieska,194,0,0.00%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Stredné Plachtince,90,0,0.00%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Sucháň,170,0,0.00%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Veľké Zlievce + Malé Zlievce,253,0,0.00%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Veľký Lom + Suché Brezovo,199,0,0.00%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Vrbovka + Kiarov,263,0,0.00%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Závada + Pravica + Chrťany,409,0,0.00%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Zombor + Glabušovce,151,0,0.00%,,,
-Zvolen,Banskobystrický,Veľký Krtíš,Želovce,709,0,0.00%,,,
-Zvolen,Banskobystrický,Lučenec,Belina,503,0,0.00%,,,
-Zvolen,Banskobystrický,Lučenec,Budiná,129,0,0.00%,,,
-Zvolen,Banskobystrický,Lučenec,Gregorova Vieska,100,0,0.00%,,,
-Zvolen,Banskobystrický,Lučenec,Holiša,611,0,0.00%,,,
-Zvolen,Banskobystrický,Lučenec,Lehôtka,511,0,0.00%,,,
-Zvolen,Banskobystrický,Lučenec,Pleš,115,0,0.00%,,,
-Zvolen,Banskobystrický,Lučenec,Šávoľ,574,0,0.00%,,,
-Zvolen,Banskobystrický,Lučenec,Šiatorská Bukovinka,421,0,0.00%,,,
-Zvolen,Banskobystrický,Lučenec,Šíd,743,0,0.00%,,,
-Zvolen,Banskobystrický,Lučenec,Trenč,430,0,0.00%,,,
-Zvolen,Banskobystrický,Krupina,Čabradský Vrbovok,215,0,0.00%,,,
-Zvolen,Banskobystrický,Krupina,Dolné Mladonice,74,0,0.00%,,,
-Zvolen,Banskobystrický,Krupina,Domaníky,139,0,0.00%,,,
-Zvolen,Banskobystrický,Krupina,Hontianske Tesáre,527,0,0.00%,,,
-Zvolen,Banskobystrický,Krupina,Horný Badín,99,0,0.00%,,,
-Zvolen,Banskobystrický,Krupina,Litava,605,0,0.00%,,,
-Zvolen,Banskobystrický,Krupina,Senohrad,505,0,0.00%,,,
-Zvolen,Banskobystrický,Banská Štiavnica,Baďan,292,0,0.00%,,,
-Zvolen,Banskobystrický,Banská Štiavnica,Dekýš,181,0,0.00%,,,
-Zvolen,Banskobystrický,Banská Štiavnica,Ilija,370,0,0.00%,,,
-Zvolen,Banskobystrický,Banská Štiavnica,Prenčov,486,0,0.00%,,,
-Zvolen,Banskobystrický,Banská Štiavnica,Svätý Anton,743,0,0.00%,,,
+State,County,Municipality,E2_tested,E2_positive,E2_relative,E3_tested,E3_positive,E3_relative,E4_tested,E4_positive,E4_relative,E4_residents_tested,E4_residents_positive,E4_residents_relative,E4_transients_tested,E4_transients_positive,E4_transients_relative
+Banskobystrický,,mobilné tímy,4370,14,0.0032,,,,,,,,,,,,
+Banskobystrický,Banská Bystrica,Badín,1580,8,0.0051,1455,4,0.0027,,,,,,,,,
+Banskobystrický,Banská Bystrica,Baláže,170,4,0.0235,196,2,0.0102,117,3,0.0256,54,0,0,63,3,0.0476
+Banskobystrický,Banská Bystrica,Banská Bystrica,36340,379,0.0104,41007,135,0.0033,,,,,,,,,
+Banskobystrický,Banská Bystrica,Brusno,1305,18,0.0138,1432,9,0.0063,,,,,,,,,
+Banskobystrický,Banská Bystrica,Čerín,635,7,0.011,295,2,0.0068,,,,,,,,,
+Banskobystrický,Banská Bystrica,Dolný Harmanec,163,0,0,228,0,0,,,,,,,,,
+Banskobystrický,Banská Bystrica,Donovaly,651,9,0.0138,851,1,0.0012,,,,,,,,,
+Banskobystrický,Banská Bystrica,Dúbravica,410,4,0.0098,337,2,0.0059,,,,,,,,,
+Banskobystrický,Banská Bystrica,Harmanec,700,6,0.0086,638,3,0.0047,,,,,,,,,
+Banskobystrický,Banská Bystrica,Hiadeľ,395,3,0.0076,385,3,0.0078,,,,,,,,,
+Banskobystrický,Banská Bystrica,Horná Mičiná,685,3,0.0044,576,3,0.0052,,,,,,,,,
+Banskobystrický,Banská Bystrica,Horné Pršany,416,8,0.0192,429,1,0.0023,,,,,,,,,
+Banskobystrický,Banská Bystrica,Hrochoť,862,12,0.0139,895,2,0.0022,,,,,,,,,
+Banskobystrický,Banská Bystrica,Hronsek,686,3,0.0044,586,0,0,,,,,,,,,
+Banskobystrický,Banská Bystrica,Kordíky,623,5,0.008,536,1,0.0019,,,,,,,,,
+Banskobystrický,Banská Bystrica,Králiky,660,9,0.0136,666,1,0.0015,,,,,,,,,
+Banskobystrický,Banská Bystrica,Kynceľová,476,4,0.0084,474,1,0.0021,,,,,,,,,
+Banskobystrický,Banská Bystrica,Ľubietová,857,12,0.014,837,4,0.0048,,,,,,,,,
+Banskobystrický,Banská Bystrica,Lučatín,598,6,0.01,564,0,0,,,,,,,,,
+Banskobystrický,Banská Bystrica,Malachov,767,2,0.0026,777,2,0.0026,,,,,,,,,
+Banskobystrický,Banská Bystrica,Medzibrod,1061,18,0.017,963,6,0.0062,,,,,,,,,
+Banskobystrický,Banská Bystrica,Moštenica,274,3,0.0109,283,1,0.0035,,,,,,,,,
+Banskobystrický,Banská Bystrica,Môlča,256,3,0.0117,270,0,0,,,,,,,,,
+Banskobystrický,Banská Bystrica,Nemce,863,14,0.0162,833,7,0.0084,,,,,,,,,
+Banskobystrický,Banská Bystrica,Podkonice,552,12,0.0217,539,1,0.0019,,,,,,,,,
+Banskobystrický,Banská Bystrica,Poniky,1030,5,0.0049,1123,1,0.0009,,,,,,,,,
+Banskobystrický,Banská Bystrica,Povrazník,173,0,0,193,0,0,,,,,,,,,
+Banskobystrický,Banská Bystrica,Priechod,694,9,0.013,651,1,0.0015,,,,,,,,,
+Banskobystrický,Banská Bystrica,Riečka,889,9,0.0101,709,2,0.0028,,,,,,,,,
+Banskobystrický,Banská Bystrica,Sebedín - Bečov,194,2,0.0103,213,1,0.0047,,,,,,,,,
+Banskobystrický,Banská Bystrica,Selce,1593,30,0.0188,1415,5,0.0035,,,,,,,,,
+Banskobystrický,Banská Bystrica,Slovenská Ľupča,2083,16,0.0077,2200,20,0.0091,,,,,,,,,
+Banskobystrický,Banská Bystrica,Staré Hory,690,4,0.0058,750,0,0,,,,,,,,,
+Banskobystrický,Banská Bystrica,Strelníky,594,17,0.0286,571,0,0,,,,,,,,,
+Banskobystrický,Banská Bystrica,Špania Dolina,613,4,0.0065,444,0,0,,,,,,,,,
+Banskobystrický,Banská Bystrica,Tajov,641,5,0.0078,763,5,0.0066,,,,,,,,,
+Banskobystrický,Banská Bystrica,Vlkanová,990,16,0.0162,1012,5,0.0049,,,,,,,,,
+Banskobystrický,Banská Štiavnica,Baďan,292,0,0,,,,,,,,,,,,
+Banskobystrický,Banská Štiavnica,Banská Belá,696,3,0.0043,,,,,,,,,,,,
+Banskobystrický,Banská Štiavnica,Banská Štiavnica,7697,22,0.0029,,,,,,,,,,,,
+Banskobystrický,Banská Štiavnica,Banský Studenec,403,1,0.0025,,,,,,,,,,,,
+Banskobystrický,Banská Štiavnica,Dekýš,181,0,0,,,,,,,,,,,,
+Banskobystrický,Banská Štiavnica,Ilija,370,0,0,,,,,,,,,,,,
+Banskobystrický,Banská Štiavnica,Kozelník,95,2,0.0211,,,,48,2,0.0417,18,0,0,30,2,0.0667
+Banskobystrický,Banská Štiavnica,Močiar,97,1,0.0103,,,,36,0,0,20,0,0,16,0,0
+Banskobystrický,Banská Štiavnica,Prenčov,486,0,0,,,,,,,,,,,,
+Banskobystrický,Banská Štiavnica,Svätý Anton,743,0,0,,,,,,,,,,,,
+Banskobystrický,Banská Štiavnica,Štiavnické Bane,635,4,0.0063,,,,,,,,,,,,
+Banskobystrický,Brezno,Bacúch,598,3,0.005,653,1,0.0015,,,,,,,,,
+Banskobystrický,Brezno,Beňuš,712,8,0.0112,685,5,0.0073,,,,,,,,,
+Banskobystrický,Brezno,Braväcovo,514,2,0.0039,571,1,0.0018,,,,,,,,,
+Banskobystrický,Brezno,Brezno,11583,125,0.0108,12451,78,0.0063,,,,,,,,,
+Banskobystrický,Brezno,Bystrá,482,5,0.0104,470,0,0,,,,,,,,,
+Banskobystrický,Brezno,Čierny Balog,3092,40,0.0129,3166,18,0.0057,,,,,,,,,
+Banskobystrický,Brezno,Dolná Lehota,788,5,0.0063,707,8,0.0113,167,0,0,131,0,0,36,0,0
+Banskobystrický,Brezno,Heľpa,1364,26,0.0191,1382,12,0.0087,,,,,,,,,
+Banskobystrický,Brezno,Horná Lehota,512,8,0.0156,480,2,0.0042,,,,,,,,,
+Banskobystrický,Brezno,Hronec,755,8,0.0106,656,4,0.0061,,,,,,,,,
+Banskobystrický,Brezno,Jasenie,655,12,0.0183,719,8,0.0111,311,5,0.0161,265,4,0.0151,46,1,0.0217
+Banskobystrický,Brezno,Lom nad Rimavicou,501,1,0.002,,,,,,,,,,,,
+Banskobystrický,Brezno,Michalová,825,5,0.0061,864,6,0.0069,,,,,,,,,
+Banskobystrický,Brezno,Mýto pod Ďumbierom,492,3,0.0061,495,0,0,,,,,,,,,
+Banskobystrický,Brezno,Nemecká,1178,16,0.0136,1180,3,0.0025,,,,,,,,,
+Banskobystrický,Brezno,Osrblie,363,13,0.0358,347,1,0.0029,,,,,,,,,
+Banskobystrický,Brezno,Podbrezová,1894,21,0.0111,2181,14,0.0064,,,,,,,,,
+Banskobystrický,Brezno,Pohorelá,980,10,0.0102,1306,8,0.0061,,,,,,,,,
+Banskobystrický,Brezno,Pohorelá - Maša,248,4,0.0161,,,,,,,,,,,,
+Banskobystrický,Brezno,Pohronská Polhora,1038,13,0.0125,1317,3,0.0023,,,,,,,,,
+Banskobystrický,Brezno,Polomka,1719,25,0.0145,1883,16,0.0085,,,,,,,,,
+Banskobystrický,Brezno,Predajná,824,10,0.0121,772,2,0.0026,,,,,,,,,
+Banskobystrický,Brezno,Ráztoka,337,0,0,312,0,0,,,,,,,,,
+Banskobystrický,Brezno,Šumiac,790,9,0.0114,842,10,0.0119,236,10,0.0424,166,8,0.0482,70,2,0.0286
+Banskobystrický,Brezno,Telgárt,1005,12,0.0119,1041,6,0.0058,,,,,,,,,
+Banskobystrický,Brezno,Valaská,1829,31,0.0169,1905,21,0.011,475,14,0.0295,396,11,0.0278,79,3,0.038
+Banskobystrický,Brezno,Vaľkovňa,341,3,0.0088,349,5,0.0143,80,6,0.075,22,0,0,58,6,0.1034
+Banskobystrický,Brezno,Závadka nad Hronom,1360,29,0.0213,1209,10,0.0083,,,,,,,,,
+Banskobystrický,Detva,Detva,7605,89,0.0117,10210,29,0.0028,,,,,,,,,
+Banskobystrický,Detva,Detvianska Huta,618,3,0.0049,686,1,0.0015,,,,,,,,,
+Banskobystrický,Detva,Dúbravy,924,7,0.0076,778,5,0.0064,,,,,,,,,
+Banskobystrický,Detva,Hriňová,4053,64,0.0158,4311,18,0.0042,,,,,,,,,
+Banskobystrický,Detva,Klokoč,285,2,0.007,300,1,0.0033,,,,,,,,,
+Banskobystrický,Detva,Korytárky,844,10,0.0118,902,4,0.0044,,,,,,,,,
+Banskobystrický,Detva,Kriváň,1381,6,0.0043,1633,10,0.0061,,,,,,,,,
+Banskobystrický,Detva,Látky,536,3,0.0056,701,0,0,,,,,,,,,
+Banskobystrický,Detva,Podkriváň,482,5,0.0104,646,3,0.0046,,,,,,,,,
+Banskobystrický,Detva,Slatinské Lazy,517,2,0.0039,460,0,0,,,,,,,,,
+Banskobystrický,Detva,Stará Huta / Horný Tisovník,362,1,0.0028,287,1,0.0035,,,,,,,,,
+Banskobystrický,Detva,Stožok,816,14,0.0172,792,2,0.0025,,,,,,,,,
+Banskobystrický,Detva,Vígľaská Huta - Kalinka,190,0,0,250,1,0.004,,,,,,,,,
+Banskobystrický,Detva,Vígľaš,1016,5,0.0049,1083,4,0.0037,,,,,,,,,
+Banskobystrický,Krupina,Bzovík,1060,6,0.0057,,,,,,,,,,,,
+Banskobystrický,Krupina,Cerovo,409,2,0.0049,,,,,,,,,,,,
+Banskobystrický,Krupina,Čabradský Vrbovok,215,0,0,,,,,,,,,,,,
+Banskobystrický,Krupina,Čekovce,421,2,0.0048,,,,,,,,,,,,
+Banskobystrický,Krupina,Devičie,311,1,0.0032,,,,,,,,,,,,
+Banskobystrický,Krupina,Dolné Mladonice,74,0,0,,,,,,,,,,,,
+Banskobystrický,Krupina,Dolný Badín,314,1,0.0032,,,,,,,,,,,,
+Banskobystrický,Krupina,Domaníky,139,0,0,,,,,,,,,,,,
+Banskobystrický,Krupina,Dudince,801,7,0.0087,,,,,,,,,,,,
+Banskobystrický,Krupina,Hontianske Moravce,421,6,0.0143,,,,142,2,0.0141,120,2,0.0167,22,0,0
+Banskobystrický,Krupina,Hontianske Nemce,830,7,0.0084,,,,,,,,,,,,
+Banskobystrický,Krupina,Hontianske Tesáre,527,0,0,,,,,,,,,,,,
+Banskobystrický,Krupina,Horný Badín,99,0,0,,,,,,,,,,,,
+Banskobystrický,Krupina,Kráľovce - Krnišov,265,1,0.0038,,,,,,,,,,,,
+Banskobystrický,Krupina,Krupina,3903,18,0.0046,,,,,,,,,,,,
+Banskobystrický,Krupina,Ladzany,337,4,0.0119,,,,66,0,0,53,0,0,13,0,0
+Banskobystrický,Krupina,Lišov,146,2,0.0137,,,,102,3,0.0294,81,3,0.037,21,0,0
+Banskobystrický,Krupina,Litava,605,0,0,,,,,,,,,,,,
+Banskobystrický,Krupina,Rykynčice,316,2,0.0063,,,,,,,,,,,,
+Banskobystrický,Krupina,Sebechleby,759,4,0.0053,,,,,,,,,,,,
+Banskobystrický,Krupina,Senohrad,505,0,0,,,,,,,,,,,,
+Banskobystrický,Krupina,Súdovce,166,2,0.012,,,,68,0,0,50,0,0,18,0,0
+Banskobystrický,Krupina,Terany,352,1,0.0028,,,,,,,,,,,,
+Banskobystrický,Lučenec,Ábelová,245,1,0.0041,,,,,,,,,,,,
+Banskobystrický,Lučenec,Belina,503,0,0,,,,,,,,,,,,
+Banskobystrický,Lučenec,Biskupice,806,2,0.0025,,,,,,,,,,,,
+Banskobystrický,Lučenec,Boľkovce,304,2,0.0066,,,,,,,,,,,,
+Banskobystrický,Lučenec,Budiná,129,0,0,,,,,,,,,,,,
+Banskobystrický,Lučenec,Buzitka,522,4,0.0077,,,,,,,,,,,,
+Banskobystrický,Lučenec,Čakanovce,684,2,0.0029,,,,,,,,,,,,
+Banskobystrický,Lučenec,Divín,1308,4,0.0031,,,,,,,,,,,,
+Banskobystrický,Lučenec,Dobroč,432,2,0.0046,,,,,,,,,,,,
+Banskobystrický,Lučenec,Fiľakovo,5607,28,0.005,,,,,,,,,,,,
+Banskobystrický,Lučenec,Fiľakovské Kováče,700,1,0.0014,,,,,,,,,,,,
+Banskobystrický,Lučenec,Gregorova Vieska,100,0,0,,,,,,,,,,,,
+Banskobystrický,Lučenec,Halič,1266,7,0.0055,,,,,,,,,,,,
+Banskobystrický,Lučenec,Holiša,611,0,0,,,,,,,,,,,,
+Banskobystrický,Lučenec,Kalonda,138,1,0.0072,,,,,,,,,,,,
+Banskobystrický,Lučenec,Kotmanová,283,1,0.0035,,,,,,,,,,,,
+Banskobystrický,Lučenec,Lehôtka,511,0,0,,,,,,,,,,,,
+Banskobystrický,Lučenec,Lovinobaňa,1049,10,0.0095,,,,,,,,,,,,
+Banskobystrický,Lučenec,Ľuboreč,258,1,0.0039,,,,,,,,,,,,
+Banskobystrický,Lučenec,Lučenec,12445,83,0.0067,,,,,,,,,,,,
+Banskobystrický,Lučenec,Mikušovce,163,2,0.0123,,,,109,2,0.0183,42,0,0,67,2,0.0299
+Banskobystrický,Lučenec,Mučín,591,3,0.0051,,,,,,,,,,,,
+Banskobystrický,Lučenec,Mýtna,842,15,0.0178,,,,273,23,0.0842,76,1,0.0132,197,22,0.1117
+Banskobystrický,Lučenec,Panické Dravce,611,2,0.0033,,,,,,,,,,,,
+Banskobystrický,Lučenec,Pinciná,320,1,0.0031,,,,,,,,,,,,
+Banskobystrický,Lučenec,Pleš,115,0,0,,,,,,,,,,,,
+Banskobystrický,Lučenec,Podrečany,426,2,0.0047,,,,,,,,,,,,
+Banskobystrický,Lučenec,Radzovce,758,2,0.0026,,,,,,,,,,,,
+Banskobystrický,Lučenec,Rapovce,675,3,0.0044,,,,,,,,,,,,
+Banskobystrický,Lučenec,Ružiná,561,1,0.0018,,,,,,,,,,,,
+Banskobystrický,Lučenec,Stará Halič,406,3,0.0074,,,,,,,,,,,,
+Banskobystrický,Lučenec,Šávoľ,574,0,0,,,,,,,,,,,,
+Banskobystrický,Lučenec,Šiatorská Bukovinka,421,0,0,,,,,,,,,,,,
+Banskobystrický,Lučenec,Šíd,743,0,0,,,,,,,,,,,,
+Banskobystrický,Lučenec,Šurice,277,1,0.0036,,,,,,,,,,,,
+Banskobystrický,Lučenec,Točnica,363,3,0.0083,,,,,,,,,,,,
+Banskobystrický,Lučenec,Tomášovce,958,9,0.0094,,,,,,,,,,,,
+Banskobystrický,Lučenec,Trebeľovce,689,5,0.0073,,,,,,,,,,,,
+Banskobystrický,Lučenec,Trenč,430,0,0,,,,,,,,,,,,
+Banskobystrický,Lučenec,Tuhár,364,2,0.0055,,,,,,,,,,,,
+Banskobystrický,Lučenec,Veľká nad Ipľom,688,3,0.0044,,,,,,,,,,,,
+Banskobystrický,Lučenec,Veľké Dravce,536,2,0.0037,,,,,,,,,,,,
+Banskobystrický,Lučenec,Vidiná,1164,5,0.0043,,,,,,,,,,,,
+Banskobystrický,Poltár,Breznička,500,1,0.002,,,,,,,,,,,,
+Banskobystrický,Poltár,Cinobaňa,1296,5,0.0039,,,,,,,,,,,,
+Banskobystrický,Poltár,České Brezovo,238,1,0.0042,,,,,,,,,,,,
+Banskobystrický,Poltár,Ďubákovo,59,0,0,,,,,,,,,,,,
+Banskobystrický,Poltár,Hradište,144,2,0.0139,,,,15,0,0,10,0,0,5,0,0
+Banskobystrický,Poltár,Hrnčiarska Ves,463,9,0.0194,,,,73,4,0.0548,33,0,0,40,4,0.1
+Banskobystrický,Poltár,Hrnčiarske Zalužany,611,1,0.0016,,,,,,,,,,,,
+Banskobystrický,Poltár,Kalinovo,1363,7,0.0051,,,,,,,,,,,,
+Banskobystrický,Poltár,Kokava nad Rimavicou,1437,4,0.0028,,,,,,,,,,,,
+Banskobystrický,Poltár,Krná,46,0,0,,,,,,,,,,,,
+Banskobystrický,Poltár,Málinec,722,1,0.0014,,,,,,,,,,,,
+Banskobystrický,Poltár,Mládzovo,66,0,0,,,,,,,,,,,,
+Banskobystrický,Poltár,Ozdín,305,1,0.0033,,,,,,,,,,,,
+Banskobystrický,Poltár,Poltár,3201,25,0.0078,,,,,,,,,,,,
+Banskobystrický,Poltár,Rovňany,135,0,0,,,,,,,,,,,,
+Banskobystrický,Poltár,Selce,118,3,0.0254,,,,19,0,0,10,0,0,9,0,0
+Banskobystrický,Poltár,Sušany,308,3,0.0097,,,,,,,,,,,,
+Banskobystrický,Poltár,Šoltýska,112,1,0.0089,,,,,,,,,,,,
+Banskobystrický,Poltár,Uhorské,272,3,0.011,,,,39,0,0,23,0,0,16,0,0
+Banskobystrický,Poltár,Utekáč,608,0,0,,,,,,,,,,,,
+Banskobystrický,Poltár,Veľká Ves,252,3,0.0119,,,,150,7,0.0467,66,0,0,84,7,0.0833
+Banskobystrický,Poltár,Zlatno,199,1,0.005,,,,,,,,,,,,
+Banskobystrický,Revúca,Gemer,557,1,0.0018,,,,,,,,,,,,
+Banskobystrický,Revúca,Gemerská Ves,566,3,0.0053,,,,,,,,,,,,
+Banskobystrický,Revúca,Gemerské Teplice,435,0,0,,,,,,,,,,,,
+Banskobystrický,Revúca,Gemerský Sad,190,0,0,,,,,,,,,,,,
+Banskobystrický,Revúca,Hucín,528,0,0,,,,,,,,,,,,
+Banskobystrický,Revúca,Chvalová,184,1,0.0054,,,,,,,,,,,,
+Banskobystrický,Revúca,Chyžné,228,0,0,,,,,,,,,,,,
+Banskobystrický,Revúca,Jelšava,1472,16,0.0109,,,,409,3,0.0073,338,0,0,71,3,0.0423
+Banskobystrický,Revúca,Kameňany,512,0,0,,,,,,,,,,,,
+Banskobystrický,Revúca,Leváre + Držkovce,346,2,0.0058,,,,,,,,,,,,
+Banskobystrický,Revúca,Levkuška,153,1,0.0065,,,,,,,,,,,,
+Banskobystrický,Revúca,Licince,564,1,0.0018,,,,,,,,,,,,
+Banskobystrický,Revúca,Lubeník,699,3,0.0043,,,,,,,,,,,,
+Banskobystrický,Revúca,Magnezitovce,317,0,0,,,,,,,,,,,,
+Banskobystrický,Revúca,Mokrá Lúka,480,0,0,,,,,,,,,,,,
+Banskobystrický,Revúca,Muráň,764,0,0,,,,,,,,,,,,
+Banskobystrický,Revúca,Muránska Dlhá Lúka,641,2,0.0031,,,,,,,,,,,,
+Banskobystrický,Revúca,Muránska Huta,311,1,0.0032,,,,,,,,,,,,
+Banskobystrický,Revúca,Muránska Lehota,224,0,0,,,,,,,,,,,,
+Banskobystrický,Revúca,Muránska Zdychava,178,0,0,,,,,,,,,,,,
+Banskobystrický,Revúca,Nandraž,167,0,0,,,,,,,,,,,,
+Banskobystrický,Revúca,Otročok,256,1,0.0039,,,,,,,,,,,,
+Banskobystrický,Revúca,Ploské,0,0,0,,,,,,,,,,,,
+Banskobystrický,Revúca,Rákoš,223,0,0,,,,,,,,,,,,
+Banskobystrický,Revúca,Rašice,276,0,0,,,,,,,,,,,,
+Banskobystrický,Revúca,Ratková,187,2,0.0107,,,,81,1,0.0123,65,1,0.0154,16,0,0
+Banskobystrický,Revúca,Ratková,187,2,0.0107,,,,,,,,,,,,
+Banskobystrický,Revúca,Ratkovské Bystré,277,0,0,,,,,,,,,,,,
+Banskobystrický,Revúca,Revúca,5579,10,0.0018,,,,,,,,,,,,
+Banskobystrický,Revúca,Revúcka Lehota,265,0,0,,,,,,,,,,,,
+Banskobystrický,Revúca,Rybník,61,0,0,,,,,,,,,,,,
+Banskobystrický,Revúca,Sása,132,0,0,,,,,,,,,,,,
+Banskobystrický,Revúca,Sirk,594,0,0,,,,,,,,,,,,
+Banskobystrický,Revúca,Skerešovo,111,0,0,,,,,,,,,,,,
+Banskobystrický,Revúca,Šivetice,122,0,0,,,,,,,,,,,,
+Banskobystrický,Revúca,Tornaľa,3569,14,0.0039,,,,,,,,,,,,
+Banskobystrický,Revúca,Turčok,156,0,0,,,,,,,,,,,,
+Banskobystrický,Revúca,Žiar,95,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Abovce,464,3,0.0065,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Babinec,0,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Barca,281,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Bátka,615,8,0.013,,,,200,7,0.035,111,0,0,89,7,0.0787
+Banskobystrický,Rimavská Sobota,Belín,113,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Blhovce,559,2,0.0036,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Bottovo,145,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Cakov,21,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Čerenčany,448,2,0.0045,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Čierny Potok,304,3,0.0099,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Číž,408,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Dolné Zahorany,252,1,0.004,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Dražice,235,3,0.0128,,,,95,0,0,71,0,0,24,0,0
+Banskobystrický,Rimavská Sobota,Drienčany,0,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Drňa,190,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Dubno,104,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Dubovec,271,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Dulovo,220,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Figa,246,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Gemerček,99,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Gemerské Dechtáre,240,1,0.0042,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Gemerské Michalovce,175,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Gemerský Jablonec,476,2,0.0042,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Gortva,293,5,0.0171,,,,116,3,0.0259,82,3,0.0366,34,0,0
+Banskobystrický,Rimavská Sobota,Hajnáčka,656,3,0.0046,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Hnúšťa,3409,24,0.007,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Hodejov,1011,5,0.0049,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Hodejovec,127,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Horné Zahorany,105,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Hostice,615,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Hrachovo,612,4,0.0065,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Hrušovo,24,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Husiná,249,2,0.008,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Chanava,482,1,0.0021,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Chrámec,139,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Janice,257,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Jesenské,1345,3,0.0022,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Jestice,104,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Kaloša,437,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Kesovce,50,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Klenovec,1727,14,0.0081,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Kociha,505,1,0.002,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Konrádovce,0,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Kráľ,575,2,0.0035,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Kraskovo,194,1,0.0052,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Krokava,0,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Kružno,344,1,0.0029,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Lehota nad Rimavicou,140,1,0.0071,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Lenartovce,348,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Lenka + Hubovo,423,2,0.0047,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Lipovec,52,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Lukovištia,318,4,0.0126,,,,38,0,0,19,0,0,19,0,0
+Banskobystrický,Rimavská Sobota,Martinová,334,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Neporadza,154,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Nižný Skálnik,219,2,0.0091,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Nová Bašta,260,2,0.0077,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Orávka,202,3,0.0149,,,,38,0,0,18,0,0,20,0,0
+Banskobystrický,Rimavská Sobota,Ožďany,1263,3,0.0024,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Padarovce,31,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Pavlovce,498,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Petrovce,117,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Poproč,91,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Potok,1,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Radnovce,722,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Rakytník,203,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Ratkovská Lehota,126,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Ratkovská Suchá,73,2,0.0274,,,,18,0,0,9,0,0,9,0,0
+Banskobystrický,Rimavská Sobota,Riečka,352,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Rimavská Baňa,460,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Rimavská Seč,1114,2,0.0018,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Rimavská Sobota,9984,40,0.004,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Rimavské Brezovo,230,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Rimavské Janovce,722,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Rimavské Zalužany,178,4,0.0225,,,,188,6,0.0319,71,0,0,117,6,0.0513
+Banskobystrický,Rimavská Sobota,Rovné,116,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Rumince,232,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Slizké,55,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Stará Bašta,181,1,0.0055,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Stránska,286,1,0.0035,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Studená,239,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Sútor,259,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Šimonovce,270,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Širkovce,436,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Španie Pole,160,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Štrkovec,193,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Tachty,294,5,0.017,,,,195,1,0.0051,154,1,0.0065,41,0,0
+Banskobystrický,Rimavská Sobota,Teplý Vrch,361,1,0.0028,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Tisovec,2301,10,0.0043,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Tomášovce,272,6,0.0221,,,,7,0,0,0,0,0,7,0,0
+Banskobystrický,Rimavská Sobota,Uzovská Panica,254,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Valice,188,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Včelince,404,1,0.0025,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Večelkov,308,3,0.0097,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Veľké Teriakovce,528,5,0.0095,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Veľký Blh,786,2,0.0025,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Vlkyňa,361,4,0.0111,,,,63,0,0,49,0,0,14,0,0
+Banskobystrický,Rimavská Sobota,Vyšné Valice,149,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Vyšný Skálnik,153,1,0.0065,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Zádor,0,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Zacharovce,156,0,0,,,,,,,,,,,,
+Banskobystrický,Rimavská Sobota,Žíp,189,0,0,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Balog nad Ipľom,572,2,0.0035,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Bátorová,196,2,0.0102,,,,102,1,0.0098,54,0,0,48,1,0.0208
+Banskobystrický,Veľký Krtíš,Bušince + Muľa,958,1,0.001,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Čebovce,628,1,0.0016,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Čeláre,250,0,0,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Čelovce,372,0,0,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Dačov Lom,268,0,0,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Dolinka,304,3,0.0099,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Dolná Strehová + Ľuboriečka,918,6,0.0065,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Dolné Plachtince,661,2,0.003,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Horné Plachtince,355,0,0,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Horné Strháre + Dolné Strháre,308,1,0.0032,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Hrušov,538,0,0,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Ipeľské Predmostie,412,3,0.0073,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Kamenné Kosihy + Širákov + Ďurkovce + Seľany,423,1,0.0024,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Kleňany,209,0,0,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Koláre + Chrastince,203,1,0.0049,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Kosihovce + Opava,447,3,0.0067,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Kosihy nad Ipľom,162,5,0.0309,,,,90,1,0.0111,43,0,0,47,1,0.0213
+Banskobystrický,Veľký Krtíš,Kováčovce,279,0,0,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Lesenice + Trebušovce,510,4,0.0078,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Malý Krtíš,536,0,0,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Modrý Kameň,1150,3,0.0026,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Nenince,778,4,0.0051,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Obeckov + Nová Ves,245,0,0,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Olováry,240,1,0.0042,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Opatovská Nová Ves + Slovenské Ďarmoty,699,5,0.0072,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Pôtor,417,0,0,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Pôtor - Žihľava,140,0,0,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Príbelce,362,0,0,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Sečianky,193,3,0.0155,,,,72,0,0,58,0,0,14,0,0
+Banskobystrický,Veľký Krtíš,Senné + Brusník + Šuľa + Červeňany,229,0,0,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Sklabiná,701,1,0.0014,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Slovenské Kľačany + Vieska,194,0,0,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Stredné Plachtince,90,0,0,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Sucháň,170,0,0,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Veľká Čalomija + Malá Čalomija,373,1,0.0027,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Veľká Ves nad Ipľom,313,4,0.0128,,,,129,1,0.0078,102,0,0,27,1,0.037
+Banskobystrický,Veľký Krtíš,Veľké Straciny + Malé Straciny,320,1,0.0031,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Veľké Zlievce + Malé Zlievce,253,0,0,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Veľký Krtíš,4869,16,0.0033,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Veľký Lom + Suché Brezovo,199,0,0,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Vinica,911,1,0.0011,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Vrbovka + Kiarov,263,0,0,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Záhorce + Selešťany,395,1,0.0025,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Závada + Pravica + Chrťany,409,0,0,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Zombor + Glabušovce,151,0,0,,,,,,,,,,,,
+Banskobystrický,Veľký Krtíš,Želovce,709,0,0,,,,,,,,,,,,
+Banskobystrický,Zvolen,Babiná,160,0,0,446,3,0.0067,,,,,,,,,
+Banskobystrický,Zvolen,Budča,1193,3,0.0025,1433,10,0.007,,,,,,,,,
+Banskobystrický,Zvolen,Bzovská Lehôtka,91,0,0,124,0,0,,,,,,,,,
+Banskobystrický,Zvolen,Dobrá Niva,1244,1,0.0008,1873,2,0.0011,,,,,,,,,
+Banskobystrický,Zvolen,Dubové + Breziny + Michalková,152,0,0,235,0,0,,,,,,,,,
+Banskobystrický,Zvolen,Hronská Breznica,153,0,0,341,6,0.0176,96,4,0.0417,38,0,0,58,4,0.069
+Banskobystrický,Zvolen,Kováčová,1089,12,0.011,1164,0,0,,,,,,,,,
+Banskobystrický,Zvolen,Lieskovec,949,5,0.0053,955,2,0.0021,,,,,,,,,
+Banskobystrický,Zvolen,Lukavica,159,1,0.0063,176,0,0,,,,,,,,,
+Banskobystrický,Zvolen,Očová,1652,2,0.0012,1688,6,0.0036,,,,,,,,,
+Banskobystrický,Zvolen,Ostrá Lúka + Bacúrov + Breziny,438,3,0.0068,478,0,0,,,,,,,,,
+Banskobystrický,Zvolen,Pliešovce,495,0,0,1546,5,0.0032,,,,,,,,,
+Banskobystrický,Zvolen,Pliešovce Zaježova,667,1,0.0015,,,,,,,,,,,,
+Banskobystrický,Zvolen,Podzámčok,482,2,0.0041,495,0,0,,,,,,,,,
+Banskobystrický,Zvolen,Sása,689,5,0.0073,801,2,0.0025,,,,,,,,,
+Banskobystrický,Zvolen,Sielnica,987,3,0.003,1015,1,0.001,,,,,,,,,
+Banskobystrický,Zvolen,Sliač,3213,22,0.0068,3978,7,0.0018,,,,,,,,,
+Banskobystrický,Zvolen,Tŕnie a Natúrovej,609,1,0.0016,388,0,0,,,,,,,,,
+Banskobystrický,Zvolen,Veľká Lúka,588,3,0.0051,526,0,0,,,,,,,,,
+Banskobystrický,Zvolen,Zvolen,20889,200,0.0096,27031,80,0.003,,,,,,,,,
+Banskobystrický,Zvolen,Zvolenská Slatina,1859,9,0.0048,1873,10,0.0053,,,,,,,,,
+Banskobystrický,Zvolen,Železná Breznica,496,1,0.002,511,0,0,,,,,,,,,
+Banskobystrický,Žarnovica,Brehy,639,0,0,,,,,,,,,,,,
+Banskobystrický,Žarnovica,Hodruša - Hámre,1454,15,0.0103,,,,343,21,0.0612,176,2,0.0114,167,19,0.1138
+Banskobystrický,Žarnovica,Hodruša - Hámre (Kopanice),79,2,0.0253,,,,107,0,0,78,0,0,29,0,0
+Banskobystrický,Žarnovica,Horné Hámre,571,1,0.0018,,,,,,,,,,,,
+Banskobystrický,Žarnovica,Hrabičov,422,2,0.0047,,,,,,,,,,,,
+Banskobystrický,Žarnovica,Hronský Beňadik,612,1,0.0016,,,,,,,,,,,,
+Banskobystrický,Žarnovica,Hronský Beňadik - Psiare,159,0,0,,,,,,,,,,,,
+Banskobystrický,Žarnovica,Kľak,100,5,0.05,,,,65,1,0.0154,29,0,0,36,1,0.0278
+Banskobystrický,Žarnovica,Malá Lehota,586,10,0.0171,,,,89,0,0,58,0,0,31,0,0
+Banskobystrický,Žarnovica,Nová Baňa,3706,20,0.0054,,,,,,,,,,,,
+Banskobystrický,Žarnovica,Orovnica,462,1,0.0022,,,,,,,,,,,,
+Banskobystrický,Žarnovica,Ostrý Grúň,410,4,0.0098,,,,,,,,,,,,
+Banskobystrický,Žarnovica,Píla,75,0,0,,,,,,,,,,,,
+Banskobystrický,Žarnovica,Rudno nad Hronom,562,2,0.0036,,,,,,,,,,,,
+Banskobystrický,Žarnovica,Tekovská Breznica,788,3,0.0038,,,,,,,,,,,,
+Banskobystrický,Žarnovica,Veľká Lehota,931,15,0.0161,,,,196,1,0.0051,148,0,0,48,1,0.0208
+Banskobystrický,Žarnovica,Veľké Pole,319,0,0,,,,,,,,,,,,
+Banskobystrický,Žarnovica,Voznica,505,6,0.0119,,,,142,11,0.0775,88,7,0.0795,54,4,0.0741
+Banskobystrický,Žarnovica,Žarnovica,2916,14,0.0048,,,,,,,,,,,,
+Banskobystrický,Žarnovica,Župkov,622,4,0.0064,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Bartošova Lehôtka,321,0,0,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Bzenica,418,2,0.0048,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Dolná Trnávka,655,4,0.0061,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Dolná Ves,478,1,0.0021,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Dolná Ždaňa,589,3,0.0051,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Hliník nad Hronom,1491,19,0.0127,,,,288,5,0.0174,209,1,0.0048,79,4,0.0506
+Banskobystrický,Žiar nad Hronom,Horná Ves,112,0,0,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Horná Ždaňa,405,0,0,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Hronská Dúbrava,255,1,0.0039,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Ihráč,371,1,0.0027,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Janova Lehota,577,1,0.0017,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Jastrabá,255,0,0,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Kopernica,207,0,0,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Kosorín,344,0,0,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Krahule,334,0,0,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Kremnica,2519,14,0.0056,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Kremnické Bane,184,2,0.0109,,,,142,1,0.007,63,0,0,79,1,0.0127
+Banskobystrický,Žiar nad Hronom,Kunešov - testuje v Kremnických Baniach,184,2,0.0109,,,,0,0,0,0,0,0,0,0,0
+Banskobystrický,Žiar nad Hronom,Ladomerská Vieska,702,5,0.0071,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Lehôtka pod Brehmi,159,1,0.0063,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Lovča,202,0,0,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Lovčica - Trubín,1042,3,0.0029,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Lúčky,231,0,0,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Lutila,1046,3,0.0029,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Nevoľné,201,0,0,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Pitelová,572,5,0.0087,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Prestavlky,482,1,0.0021,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Prochot,420,1,0.0024,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Repište,275,2,0.0073,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Sklené Teplice,434,7,0.0161,,,,84,1,0.0119,72,0,0,12,1,0.0833
+Banskobystrický,Žiar nad Hronom,Slaská,315,0,0,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Stará Kremnička,774,3,0.0039,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Trnavá Hora,886,5,0.0056,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Vyhne,659,0,0,,,,,,,,,,,,
+Banskobystrický,Žiar nad Hronom,Žiar nad Hronom,7717,22,0.0029,,,,,,,,,,,,
+Bratislavský,Bratislava I,Bratislava - Staré Mesto,28614,103,0.0036,,,,,,,,,,,,
+Bratislavský,Bratislava II,Bratislava - Podunajské Biskupice,12522,37,0.003,,,,,,,,,,,,
+Bratislavský,Bratislava II,Bratislava - Ružinov,55677,197,0.0035,,,,,,,,,,,,
+Bratislavský,Bratislava II,Bratislava - Vrakuňa,12759,111,0.0087,,,,,,,,,,,,
+Bratislavský,Bratislava III,Bratislava - Nové Mesto,29460,110,0.0037,,,,,,,,,,,,
+Bratislavský,Bratislava III,Bratislava - Rača,15955,54,0.0034,,,,,,,,,,,,
+Bratislavský,Bratislava III,Bratislava - Vajnory,4373,11,0.0025,,,,,,,,,,,,
+Bratislavský,Bratislava IV,Bratislava - Devín,1789,4,0.0022,,,,,,,,,,,,
+Bratislavský,Bratislava IV,Bratislava - Devínska Nová Ves,10903,51,0.0047,,,,,,,,,,,,
+Bratislavský,Bratislava IV,Bratislava - Dúbravka,18890,49,0.0026,,,,,,,,,,,,
+Bratislavský,Bratislava IV,Bratislava - Karlova Ves,24044,81,0.0034,,,,,,,,,,,,
+Bratislavský,Bratislava IV,Bratislava - Lamač,4964,26,0.0052,,,,,,,,,,,,
+Bratislavský,Bratislava IV,Bratislava - Záhorská Bystrica,5271,18,0.0034,,,,,,,,,,,,
+Bratislavský,Bratislava V,Bratislava - Čunovo,1623,3,0.0018,,,,,,,,,,,,
+Bratislavský,Bratislava V,Bratislava - Jarovce,2692,11,0.0041,,,,,,,,,,,,
+Bratislavský,Bratislava V,Bratislava - Petržalka,58918,243,0.0041,,,,,,,,,,,,
+Bratislavský,Bratislava V,Bratislava - Rusovce,2902,6,0.0021,,,,,,,,,,,,
+Bratislavský,Malacky,Borinka,905,5,0.0055,,,,,,,,,,,,
+Bratislavský,Malacky,Gajary,1970,8,0.0041,,,,,,,,,,,,
+Bratislavský,Malacky,Jablonové,1181,2,0.0017,,,,,,,,,,,,
+Bratislavský,Malacky,Jakubov,1204,4,0.0033,,,,,,,,,,,,
+Bratislavský,Malacky,Kostolište,1390,4,0.0029,,,,,,,,,,,,
+Bratislavský,Malacky,Kuchyňa,1490,5,0.0034,,,,,,,,,,,,
+Bratislavský,Malacky,Láb,1936,11,0.0057,,,,,,,,,,,,
+Bratislavský,Malacky,Lozorno,2141,9,0.0042,,,,,,,,,,,,
+Bratislavský,Malacky,Malacky,9929,76,0.0077,,,,,,,,,,,,
+Bratislavský,Malacky,Malé Leváre,1655,3,0.0018,,,,,,,,,,,,
+Bratislavský,Malacky,Marianka,1877,5,0.0027,,,,,,,,,,,,
+Bratislavský,Malacky,Pernek,772,0,0,,,,,,,,,,,,
+Bratislavský,Malacky,Plavecké Podhradie,726,1,0.0014,,,,,,,,,,,,
+Bratislavský,Malacky,Plavecký Mikuláš,595,6,0.0101,,,,204,6,0.0294,106,0,0,98,6,0.0612
+Bratislavský,Malacky,Plavecký Štvrtok,2214,12,0.0054,,,,,,,,,,,,
+Bratislavský,Malacky,Rohožník,2796,15,0.0054,,,,,,,,,,,,
+Bratislavský,Malacky,Sološnica,1313,8,0.0061,,,,,,,,,,,,
+Bratislavský,Malacky,Studienka,1105,7,0.0063,,,,,,,,,,,,
+Bratislavský,Malacky,Stupava,8042,60,0.0075,,,,,,,,,,,,
+Bratislavský,Malacky,Suchohrad,686,3,0.0044,,,,,,,,,,,,
+Bratislavský,Malacky,Veľké Leváre,2747,13,0.0047,,,,,,,,,,,,
+Bratislavský,Malacky,Vysoká pri Morave,1884,6,0.0032,,,,,,,,,,,,
+Bratislavský,Malacky,Záhorie (vojenský obvod),281,1,0.0036,,,,,,,,,,,,
+Bratislavský,Malacky,Záhorská Ves,1235,5,0.004,,,,,,,,,,,,
+Bratislavský,Malacky,Závod,2075,9,0.0043,,,,,,,,,,,,
+Bratislavský,Malacky,Zohor,2436,7,0.0029,,,,,,,,,,,,
+Bratislavský,Pezinok,Báhoň,1486,8,0.0054,,,,,,,,,,,,
+Bratislavský,Pezinok,Budmerice,2322,10,0.0043,,,,,,,,,,,,
+Bratislavský,Pezinok,Častá,1525,8,0.0052,,,,,,,,,,,,
+Bratislavský,Pezinok,Doľany,906,0,0,,,,,,,,,,,,
+Bratislavský,Pezinok,Dubová,997,5,0.005,,,,,,,,,,,,
+Bratislavský,Pezinok,Jablonec,768,7,0.0091,,,,,,,,,,,,
+Bratislavský,Pezinok,Limbach,1591,10,0.0063,,,,,,,,,,,,
+Bratislavský,Pezinok,Modra,6591,16,0.0024,,,,,,,,,,,,
+Bratislavský,Pezinok,Pezinok,15296,100,0.0065,,,,,,,,,,,,
+Bratislavský,Pezinok,Píla,469,3,0.0064,,,,,,,,,,,,
+Bratislavský,Pezinok,Slovenský Grob,2592,7,0.0027,,,,,,,,,,,,
+Bratislavský,Pezinok,Svätý Jur,4032,26,0.0064,,,,,,,,,,,,
+Bratislavský,Pezinok,Šenkvice,3039,10,0.0033,,,,,,,,,,,,
+Bratislavský,Pezinok,Štefanová,188,0,0,,,,,,,,,,,,
+Bratislavský,Pezinok,Viničné,1787,10,0.0056,,,,,,,,,,,,
+Bratislavský,Pezinok,Vinosady,1122,16,0.0143,,,,435,23,0.0529,192,0,0,243,23,0.0947
+Bratislavský,Pezinok,Vištuk,1090,4,0.0037,,,,,,,,,,,,
+Bratislavský,Senec,Bernolákovo,5410,33,0.0061,,,,,,,,,,,,
+Bratislavský,Senec,Blatné,1544,9,0.0058,,,,,,,,,,,,
+Bratislavský,Senec,Boldog,471,4,0.0085,,,,,,,,,,,,
+Bratislavský,Senec,Čataj,1011,4,0.004,,,,,,,,,,,,
+Bratislavský,Senec,Dunajská Lužná,4139,8,0.0019,,,,,,,,,,,,
+Bratislavský,Senec,Hamuliakovo,2148,9,0.0042,,,,,,,,,,,,
+Bratislavský,Senec,Hrubá Borša,1316,8,0.0061,,,,,,,,,,,,
+Bratislavský,Senec,Hrubý Šúr,764,16,0.0209,,,,468,19,0.0406,196,1,0.0051,272,18,0.0662
+Bratislavský,Senec,Hurbanova Ves,413,4,0.0097,,,,,,,,,,,,
+Bratislavský,Senec,Chorvátsky Grob,5650,21,0.0037,,,,,,,,,,,,
+Bratislavský,Senec,Igram,328,0,0,,,,,,,,,,,,
+Bratislavský,Senec,Ivanka pri Dunaji,5435,27,0.005,,,,,,,,,,,,
+Bratislavský,Senec,Kalinkovo,1558,5,0.0032,,,,,,,,,,,,
+Bratislavský,Senec,Kaplna,863,6,0.007,,,,,,,,,,,,
+Bratislavský,Senec,Kostolná pri Dunaj,1087,9,0.0083,,,,,,,,,,,,
+Bratislavský,Senec,Kráľová pri Senci,2290,13,0.0057,,,,,,,,,,,,
+Bratislavský,Senec,Malinovo,2733,7,0.0026,,,,,,,,,,,,
+Bratislavský,Senec,Miloslavov,4590,25,0.0054,,,,,,,,,,,,
+Bratislavský,Senec,Most pri Bratislave,2693,7,0.0026,,,,,,,,,,,,
+Bratislavský,Senec,Nová Dedinka,2225,10,0.0045,,,,,,,,,,,,
+Bratislavský,Senec,Nový Svet,156,1,0.0064,,,,,,,,,,,,
+Bratislavský,Senec,Reca,1243,15,0.0121,,,,338,9,0.0266,163,0,0,175,9,0.0514
+Bratislavský,Senec,Rovinka,3635,19,0.0052,,,,,,,,,,,,
+Bratislavský,Senec,Senec,10423,54,0.0052,,,,,,,,,,,,
+Bratislavský,Senec,Tomášov,2527,6,0.0024,,,,,,,,,,,,
+Bratislavský,Senec,Tureň,1259,6,0.0048,,,,,,,,,,,,
+Bratislavský,Senec,Veľký Biel,3280,16,0.0049,,,,,,,,,,,,
+Bratislavský,Senec,Vlky,584,1,0.0017,,,,,,,,,,,,
+Bratislavský,Senec,Zálesie,1791,8,0.0045,,,,,,,,,,,,
+Košický,Gelnica,Gelnica,3180,25,0.0079,3484,13,0.0037,,,,,,,,,
+Košický,Gelnica,Helcmanovce,856,5,0.0058,898,0,0,,,,,,,,,
+Košický,Gelnica,Henclová,103,1,0.0097,125,1,0.008,,,,,,,,,
+Košický,Gelnica,Hrišovce,177,4,0.0226,170,0,0,,,,,,,,,
+Košický,Gelnica,Jaklovce,1104,13,0.0118,1285,1,0.0008,,,,,,,,,
+Košický,Gelnica,Kluknava,1057,11,0.0104,1072,12,0.0112,380,12,0.0316,267,1,0.0037,113,11,0.0973
+Košický,Gelnica,Kojšov,294,2,0.0068,547,3,0.0055,,,,,,,,,
+Košický,Gelnica,Margecany,1301,11,0.0085,1430,4,0.0028,,,,,,,,,
+Košický,Gelnica,Mníšek nad Hnilcom,923,8,0.0087,866,1,0.0012,,,,,,,,,
+Košický,Gelnica,Nálepkovo,1665,9,0.0054,1787,17,0.0095,,,,,,,,,
+Košický,Gelnica,Prakovce,1563,6,0.0038,1616,4,0.0025,,,,,,,,,
+Košický,Gelnica,Richnava,1477,4,0.0027,1477,0,0,,,,,,,,,
+Košický,Gelnica,Smolnícka Huta,384,4,0.0104,481,0,0,,,,,,,,,
+Košický,Gelnica,Smolník,592,0,0,739,6,0.0081,,,,,,,,,
+Košický,Gelnica,Stará Voda,323,1,0.0031,386,0,0,,,,,,,,,
+Košický,Gelnica,Švedlár,1117,5,0.0045,1006,4,0.004,,,,,,,,,
+Košický,Gelnica,Úhorná,113,0,0,180,0,0,,,,,,,,,
+Košický,Gelnica,Veľký Folkmar,667,5,0.0075,801,1,0.0012,,,,,,,,,
+Košický,Gelnica,Závadka,442,13,0.0294,370,5,0.0135,167,5,0.0299,136,5,0.0368,31,0,0
+Košický,Gelnica,Žakarovce,417,2,0.0048,367,0,0,,,,,,,,,
+Košický,Košice - okolie,Bačkovík,553,1,0.0018,,,,,,,,,,,,
+Košický,Košice - okolie,Baška,1776,8,0.0045,,,,,,,,,,,,
+Košický,Košice - okolie,Belža,217,0,0,,,,,,,,,,,,
+Košický,Košice - okolie,Beniakovce,606,7,0.0116,,,,197,5,0.0254,99,1,0.0101,98,4,0.0408
+Košický,Košice - okolie,Bidovce,898,2,0.0022,,,,,,,,,,,,
+Košický,Košice - okolie,Blažice,450,5,0.0111,,,,75,0,0,52,0,0,23,0,0
+Košický,Košice - okolie,Bočiar,326,1,0.0031,,,,,,,,,,,,
+Košický,Košice - okolie,Bohdanovce,592,2,0.0034,,,,,,,,,,,,
+Košický,Košice - okolie,Boliarov,567,4,0.0071,,,,,,,,,,,,
+Košický,Košice - okolie,Budimír,978,5,0.0051,,,,,,,,,,,,
+Košický,Košice - okolie,Bukovec,696,4,0.0057,,,,,,,,,,,,
+Košický,Košice - okolie,Bunetice,246,0,0,,,,,,,,,,,,
+Košický,Košice - okolie,Buzica,707,10,0.0141,,,,213,7,0.0329,153,0,0,60,7,0.1167
+Košický,Košice - okolie,Cestice,700,6,0.0086,,,,,,,,,,,,
+Košický,Košice - okolie,Čakanovce,469,11,0.0235,,,,75,2,0.0267,46,1,0.0217,29,1,0.0345
+Košický,Košice - okolie,Čaňa,3107,35,0.0113,,,,598,3,0.005,418,0,0,180,3,0.0167
+Košický,Košice - okolie,Čečejovce,1721,22,0.0128,,,,339,5,0.0147,235,1,0.0043,104,4,0.0385
+Košický,Košice - okolie,Čižatice,213,1,0.0047,,,,,,,,,,,,
+Košický,Košice - okolie,Debraď,304,2,0.0066,,,,,,,,,,,,
+Košický,Košice - okolie,Drienovec,1319,2,0.0015,,,,,,,,,,,,
+Košický,Košice - okolie,Družstevná pri Hornáde,1435,7,0.0049,,,,,,,,,,,,
+Košický,Košice - okolie,Ďurďošík,521,5,0.0096,,,,,,,,,,,,
+Košický,Košice - okolie,Ďurkov,1068,4,0.0037,,,,,,,,,,,,
+Košický,Košice - okolie,Dvorníky - Včeláre,482,1,0.0021,,,,,,,,,,,,
+Košický,Košice - okolie,Geča,1151,6,0.0052,,,,,,,,,,,,
+Košický,Košice - okolie,Gyňov,768,10,0.013,,,,146,2,0.0137,98,2,0.0204,48,0,0
+Košický,Košice - okolie,Hačava,397,4,0.0101,,,,32,0,0,17,0,0,15,0,0
+Košický,Košice - okolie,Háj,173,2,0.0116,,,,121,3,0.0248,81,0,0,40,3,0.075
+Košický,Košice - okolie,Haniska,952,6,0.0063,,,,,,,,,,,,
+Košický,Košice - okolie,Herľany,171,4,0.0234,,,,94,7,0.0745,58,0,0,36,7,0.1944
+Košický,Košice - okolie,Hodkovce,197,0,0,,,,,,,,,,,,
+Košický,Košice - okolie,Hosťovce,266,2,0.0075,,,,,,,,,,,,
+Košický,Košice - okolie,Hrašovík,227,1,0.0044,,,,,,,,,,,,
+Košický,Košice - okolie,Hýľov,300,0,0,,,,,,,,,,,,
+Košický,Košice - okolie,Chorváty,141,3,0.0213,,,,57,1,0.0175,24,0,0,33,1,0.0303
+Košický,Košice - okolie,Chrastné,548,5,0.0091,,,,,,,,,,,,
+Košický,Košice - okolie,Janík,678,0,0,,,,,,,,,,,,
+Košický,Košice - okolie,Jasov,2065,8,0.0039,,,,,,,,,,,,
+Košický,Košice - okolie,Kalša,522,7,0.0134,,,,151,0,0,140,0,0,11,0,0
+Košický,Košice - okolie,Kecerovce,1752,2,0.0011,,,,,,,,,,,,
+Košický,Košice - okolie,Kecerovský Lipovec+ Mudrovce,258,1,0.0039,,,,,,,,,,,,
+Košický,Košice - okolie,Kechnec,1680,8,0.0048,,,,,,,,,,,,
+Košický,Košice - okolie,Kokšov - Bakša,721,2,0.0028,,,,,,,,,,,,
+Košický,Košice - okolie,Komárovce,246,0,0,,,,,,,,,,,,
+Košický,Košice - okolie,Kostoľany nad Hornádom,931,3,0.0032,,,,,,,,,,,,
+Košický,Košice - okolie,Košická Belá,883,3,0.0034,,,,,,,,,,,,
+Košický,Košice - okolie,Košická Polianka,745,6,0.0081,,,,,,,,,,,,
+Košický,Košice - okolie,Košické Oľšany,856,2,0.0023,,,,,,,,,,,,
+Košický,Košice - okolie,Košický Klečenov,168,0,0,,,,,,,,,,,,
+Košický,Košice - okolie,Kráľovce,639,8,0.0125,,,,167,10,0.0599,94,2,0.0213,73,8,0.1096
+Košický,Košice - okolie,Kysak,1180,1,0.0008,,,,,,,,,,,,
+Košický,Košice - okolie,Malá Ida,1163,0,0,,,,,,,,,,,,
+Košický,Košice - okolie,Malá Lodina +Veľká Lodina,352,0,0,,,,,,,,,,,,
+Košický,Košice - okolie,Medzev,2103,4,0.0019,,,,,,,,,,,,
+Košický,Košice - okolie,Milhosť,183,1,0.0055,,,,,,,,,,,,
+Košický,Košice - okolie,Mokrance,820,14,0.0171,,,,319,5,0.0157,228,1,0.0044,91,4,0.044
+Košický,Košice - okolie,Moldava nad Bodvou,4719,33,0.007,,,,,,,,,,,,
+Košický,Košice - okolie,Nižná Hutka,639,5,0.0078,,,,,,,,,,,,
+Košický,Košice - okolie,Nižná Kamenica,579,3,0.0052,,,,,,,,,,,,
+Košický,Košice - okolie,Nižná Myšľa,1002,0,0,,,,,,,,,,,,
+Košický,Košice - okolie,Nižný Čaj,380,5,0.0132,,,,69,1,0.0145,32,0,0,37,1,0.027
+Košický,Košice - okolie,Nižný Klátov,535,2,0.0037,,,,,,,,,,,,
+Košický,Košice - okolie,Nižný Lánec,401,4,0.01,,,,,,,,,,,,
+Košický,Košice - okolie,Nová Polhora,304,2,0.0066,,,,,,,,,,,,
+Košický,Košice - okolie,Nováčany,610,0,0,,,,,,,,,,,,
+Košický,Košice - okolie,Nový Salaš,182,0,0,,,,,,,,,,,,
+Košický,Košice - okolie,Obišovce,538,2,0.0037,,,,,,,,,,,,
+Košický,Košice - okolie,Olšovany,486,5,0.0103,,,,108,3,0.0278,60,0,0,48,3,0.0625
+Košický,Košice - okolie,Opátka,404,1,0.0025,,,,,,,,,,,,
+Košický,Košice - okolie,Opiná,412,1,0.0024,,,,,,,,,,,,
+Košický,Košice - okolie,Paňovce,652,3,0.0046,,,,,,,,,,,,
+Košický,Košice - okolie,Peder,248,3,0.0121,,,,52,0,0,43,0,0,9,0,0
+Košický,Košice - okolie,Perín - Chym,1158,3,0.0026,,,,,,,,,,,,
+Košický,Košice - okolie,Ploské,841,15,0.0178,,,,118,1,0.0085,52,0,0,66,1,0.0152
+Košický,Košice - okolie,Poproč,1442,6,0.0042,,,,,,,,,,,,
+Košický,Košice - okolie,Rákoš,339,0,0,,,,,,,,,,,,
+Košický,Košice - okolie,Rankovce,657,10,0.0152,,,,72,2,0.0278,65,0,0,7,2,0.2857
+Košický,Košice - okolie,Rešica,355,0,0,,,,,,,,,,,,
+Košický,Košice - okolie,Rozhanovce,1444,7,0.0048,,,,,,,,,,,,
+Košický,Košice - okolie,Rudník,504,2,0.004,,,,,,,,,,,,
+Košický,Košice - okolie,Ruskov,941,5,0.0053,,,,,,,,,,,,
+Košický,Košice - okolie,Sady nad Torysou,1878,11,0.0059,,,,,,,,,,,,
+Košický,Košice - okolie,Seňa,1381,3,0.0022,,,,,,,,,,,,
+Košický,Košice - okolie,Skároš,857,9,0.0105,,,,168,0,0,141,0,0,27,0,0
+Košický,Košice - okolie,Slanec + Slančík,1069,5,0.0047,,,,,,,,,,,,
+Košický,Košice - okolie,Slanská Huta,177,1,0.0056,,,,,,,,,,,,
+Košický,Košice - okolie,Slanské Nové Mesto,442,1,0.0023,,,,,,,,,,,,
+Košický,Košice - okolie,Sokoľ,907,7,0.0077,,,,,,,,,,,,
+Košický,Košice - okolie,Sokoľany,814,5,0.0061,,,,,,,,,,,,
+Košický,Košice - okolie,Svinica,598,2,0.0033,,,,,,,,,,,,
+Košický,Košice - okolie,Šemša,552,2,0.0036,,,,,,,,,,,,
+Košický,Košice - okolie,Štós,480,11,0.0229,,,,149,0,0,105,0,0,44,0,0
+Košický,Košice - okolie,Trebejov,402,0,0,,,,,,,,,,,,
+Košický,Košice - okolie,Trsťany,381,0,0,,,,,,,,,,,,
+Košický,Košice - okolie,Trstené pri Hornáde,900,6,0.0067,,,,,,,,,,,,
+Košický,Košice - okolie,Turňa nad Bodvou,1682,8,0.0048,,,,,,,,,,,,
+Košický,Košice - okolie,Turnianska Nová Ves,396,1,0.0025,,,,,,,,,,,,
+Košický,Košice - okolie,Vajkovce,755,0,0,,,,,,,,,,,,
+Košický,Košice - okolie,Valaliky,2787,32,0.0115,,,,686,7,0.0102,458,2,0.0044,228,5,0.0219
+Košický,Košice - okolie,Veľká Ida,2501,4,0.0016,,,,,,,,,,,,
+Košický,Košice - okolie,Vtáčkovce,608,5,0.0082,,,,,,,,,,,,
+Košický,Košice - okolie,Vyšná Hutka,262,6,0.0229,,,,132,4,0.0303,73,0,0,59,4,0.0678
+Košický,Košice - okolie,Vyšná Kamenica,374,3,0.008,,,,,,,,,,,,
+Košický,Košice - okolie,Vyšná Myšľa,741,6,0.0081,,,,,,,,,,,,
+Košický,Košice - okolie,Vyšný Čaj,306,1,0.0033,,,,,,,,,,,,
+Košický,Košice - okolie,Vyšný Klátov,487,0,0,,,,,,,,,,,,
+Košický,Košice - okolie,Vyšný Medzev,581,1,0.0017,,,,,,,,,,,,
+Košický,Košice - okolie,Zádiel,128,1,0.0078,,,,,,,,,,,,
+Košický,Košice - okolie,Zlatá Idka,316,3,0.0095,,,,,,,,,,,,
+Košický,Košice - okolie,Žarnov,235,2,0.0085,,,,,,,,,,,,
+Košický,Košice - okolie,Ždaňa,803,13,0.0162,,,,234,1,0.0043,188,0,0,46,1,0.0217
+Košický,Košice I,Košice - Džungľa,946,6,0.0063,,,,,,,,,,,,
+Košický,Košice I,Košice - Kavečany,1089,13,0.0119,,,,,,,,,,,,
+Košický,Košice I,Košice - Sever,9480,41,0.0043,,,,,,,,,,,,
+Košický,Košice I,Košice - Sídlisko Ťahanovce,7178,42,0.0059,,,,,,,,,,,,
+Košický,Košice I,Košice - Staré Mesto,11366,72,0.0063,,,,,,,,,,,,
+Košický,Košice I,Košice - Ťahanovce,1669,13,0.0078,,,,,,,,,,,,
+Košický,Košice II,Košice - Lorinčík,1088,6,0.0055,,,,,,,,,,,,
+Košický,Košice II,Košice - Luník IX,1292,10,0.0077,,,,,,,,,,,,
+Košický,Košice II,Košice - Myslava,1565,3,0.0019,,,,,,,,,,,,
+Košický,Košice II,Košice - Pereš,1058,2,0.0019,,,,,,,,,,,,
+Košický,Košice II,Košice - Poľov,597,5,0.0084,,,,,,,,,,,,
+Košický,Košice II,Košice - Sídlisko KVP,8608,36,0.0042,,,,,,,,,,,,
+Košický,Košice II,Košice - Šaca,3175,7,0.0022,,,,,,,,,,,,
+Košický,Košice II,Košice - Západ,21931,226,0.0103,,,,,,,,,,,,
+Košický,Košice III,Košice - Dargovských hrdinov,9568,39,0.0041,,,,,,,,,,,,
+Košický,Košice III,Košice - Košická Nová Ves,1541,2,0.0013,,,,,,,,,,,,
+Košický,Košice IV,Košice - Barca,2189,10,0.0046,,,,,,,,,,,,
+Košický,Košice IV,Košice - Juh,8557,51,0.006,,,,,,,,,,,,
+Košický,Košice IV,Košice - Krásna,3038,12,0.0039,,,,,,,,,,,,
+Košický,Košice IV,Košice - Nad jazerom,11109,59,0.0053,,,,,,,,,,,,
+Košický,Košice IV,Košice - Šebastovce,627,1,0.0016,,,,,,,,,,,,
+Košický,Košice IV,Košice - Vyšné Opátske,1472,2,0.0014,,,,,,,,,,,,
+Košický,Michalovce,Bajany,322,1,0.0031,331,2,0.006,,,,,,,,,
+Košický,Michalovce,Bánovce nad Ondavou,515,5,0.0097,601,5,0.0083,,,,,,,,,
+Košický,Michalovce,Bracovce,571,10,0.0175,578,0,0,,,,,,,,,
+Košický,Michalovce,Budkovce,658,9,0.0137,716,7,0.0098,,,,,,,,,
+Košický,Michalovce,Čičarovce,550,12,0.0218,599,3,0.005,,,,,,,,,
+Košický,Michalovce,Čierne Pole,422,0,0,404,1,0.0025,,,,,,,,,
+Košický,Michalovce,Drahňov,760,3,0.0039,712,1,0.0014,,,,,,,,,
+Košický,Michalovce,Dúbravka,542,2,0.0037,511,3,0.0059,,,,,,,,,
+Košický,Michalovce,Falkušovce,365,0,0,391,0,0,,,,,,,,,
+Košický,Michalovce,Hatalov,848,44,0.0519,437,4,0.0092,,,,,,,,,
+Košický,Michalovce,Hažín,465,4,0.0086,388,1,0.0026,,,,,,,,,
+Košický,Michalovce,Horovce,538,1,0.0019,1129,8,0.0071,,,,,,,,,
+Košický,Michalovce,Iňačovce,763,2,0.0026,756,0,0,,,,,,,,,
+Košický,Michalovce,Jovsa,665,6,0.009,656,1,0.0015,,,,,,,,,
+Košický,Michalovce,Kačanov,281,2,0.0071,297,0,0,,,,,,,,,
+Košický,Michalovce,Kaluža,449,0,0,463,0,0,,,,,,,,,
+Košický,Michalovce,Kapušianské Kľačany,550,2,0.0036,555,3,0.0054,,,,,,,,,
+Košický,Michalovce,Klokočov,444,5,0.0113,452,0,0,,,,,,,,,
+Košický,Michalovce,Krásnovce,448,0,0,481,1,0.0021,,,,,,,,,
+Košický,Michalovce,Krišovská Liesková,614,0,0,589,3,0.0051,,,,,,,,,
+Košický,Michalovce,Lastomír,750,2,0.0027,719,1,0.0014,,,,,,,,,
+Košický,Michalovce,Laškovce,438,6,0.0137,431,1,0.0023,,,,,,,,,
+Košický,Michalovce,Lesné,356,0,0,330,2,0.0061,,,,,,,,,
+Košický,Michalovce,Ložín,501,2,0.004,510,0,0,,,,,,,,,
+Košický,Michalovce,Lúčky,411,1,0.0024,424,0,0,,,,,,,,,
+Košický,Michalovce,Malčice,656,9,0.0137,698,3,0.0043,,,,,,,,,
+Košický,Michalovce,Markovce,544,48,0.0882,,,,237,6,0.0253,211,4,0.019,26,2,0.0769
+Košický,Michalovce,Maťovské Vojkovce,453,5,0.011,488,2,0.0041,,,,,,,,,
+Košický,Michalovce,Michalovce,16275,109,0.0067,17919,42,0.0023,,,,,,,,,
+Košický,Michalovce,Moravany,602,6,0.01,637,2,0.0031,,,,,,,,,
+Košický,Michalovce,Nacina Ves,1218,4,0.0033,1133,2,0.0018,,,,,,,,,
+Košický,Michalovce,Oborín,454,1,0.0022,813,3,0.0037,,,,,,,,,
+Košický,Michalovce,Oreské,319,0,0,341,1,0.0029,,,,,,,,,
+Košický,Michalovce,Palín,476,6,0.0126,479,1,0.0021,,,,,,,,,
+Košický,Michalovce,Pavlovce nad Uhom,1645,18,0.0109,1643,6,0.0037,,,,,,,,,
+Košický,Michalovce,Petrikovce,262,3,0.0115,241,0,0,,,,,,,,,
+Košický,Michalovce,Petrovce nad Laborcom,831,8,0.0096,743,0,0,,,,,,,,,
+Košický,Michalovce,Poruba pod Vihorlatom,493,0,0,472,3,0.0064,,,,,,,,,
+Košický,Michalovce,Pozdišovce,736,1,0.0014,807,5,0.0062,,,,,,,,,
+Košický,Michalovce,Ptrukša,303,4,0.0132,,,,232,5,0.0216,117,0,0,115,5,0.0435
+Košický,Michalovce,Rakovec nad Ondavou,611,3,0.0049,588,0,0,,,,,,,,,
+Košický,Michalovce,Ruská,405,2,0.0049,516,2,0.0039,,,,,,,,,
+Košický,Michalovce,Senné,360,5,0.0139,343,0,0,,,,,,,,,
+Košický,Michalovce,Slavkovce,604,20,0.0331,536,5,0.0093,,,,,,,,,
+Košický,Michalovce,Sliepkovce,496,19,0.0383,475,1,0.0021,,,,,,,,,
+Košický,Michalovce,Staré,441,1,0.0023,452,1,0.0022,,,,,,,,,
+Košický,Michalovce,Strážske,2198,13,0.0059,2275,6,0.0026,,,,,,,,,
+Košický,Michalovce,Stretava,509,1,0.002,502,0,0,,,,,,,,,
+Košický,Michalovce,Suché,430,1,0.0023,342,2,0.0058,,,,,,,,,
+Košický,Michalovce,Šamudovce,339,1,0.0029,311,0,0,,,,,,,,,
+Košický,Michalovce,Trhovište,827,8,0.0097,987,7,0.0071,,,,,,,,,
+Košický,Michalovce,Trnava pri Laborci,534,1,0.0019,499,0,0,,,,,,,,,
+Košický,Michalovce,Tušice,474,1,0.0021,778,2,0.0026,,,,,,,,,
+Košický,Michalovce,Tušická Nová Ves,341,1,0.0029,707,1,0.0014,,,,,,,,,
+Košický,Michalovce,Veľké Kapušany,4475,19,0.0042,5649,19,0.0034,,,,,,,,,
+Košický,Michalovce,Veľké Raškovce,360,8,0.0222,424,1,0.0024,,,,,,,,,
+Košický,Michalovce,Veľké Slemence,433,2,0.0046,431,2,0.0046,,,,,,,,,
+Košický,Michalovce,Vinné,1335,7,0.0052,1370,4,0.0029,,,,,,,,,
+Košický,Michalovce,Vojany,805,1,0.0012,772,1,0.0013,,,,,,,,,
+Košický,Michalovce,Voľa,391,3,0.0077,378,0,0,,,,,,,,,
+Košický,Michalovce,Vrbnica,508,16,0.0315,,,,110,10,0.0909,50,2,0.04,60,8,0.1333
+Košický,Michalovce,Vysoká nad Uhom,549,11,0.02,551,0,0,,,,,,,,,
+Košický,Michalovce,Zalužice,939,4,0.0043,896,0,0,,,,,,,,,
+Košický,Michalovce,Závadka,407,14,0.0344,389,0,0,,,,,,,,,
+Košický,Michalovce,Zbudza,491,4,0.0081,451,0,0,,,,,,,,,
+Košický,Michalovce,Zemplínska Široká,611,5,0.0082,599,0,0,,,,,,,,,
+Košický,Michalovce,Žbince,563,0,0,567,0,0,,,,,,,,,
+Košický,Rožňava,Ardovo,353,2,0.0057,,,,,,,,,,,,
+Košický,Rožňava,Betliar,546,0,0,,,,,,,,,,,,
+Košický,Rožňava,Bohúňovo,144,0,0,,,,,,,,,,,,
+Košický,Rožňava,Bôrka,338,0,0,,,,,,,,,,,,
+Košický,Rožňava,Brdárka,100,0,0,,,,,,,,,,,,
+Košický,Rožňava,Bretka,293,1,0.0034,,,,,,,,,,,,
+Košický,Rožňava,Brzotín,648,1,0.0015,,,,,,,,,,,,
+Košický,Rožňava,Čierna Lehota,426,1,0.0023,,,,,,,,,,,,
+Košický,Rožňava,Čoltovo,134,0,0,,,,,,,,,,,,
+Košický,Rožňava,Čučma,569,1,0.0018,,,,,,,,,,,,
+Košický,Rožňava,Dedinky,182,1,0.0055,,,,,,,,,,,,
+Košický,Rožňava,Dlhá Ves,357,1,0.0028,,,,,,,,,,,,
+Košický,Rožňava,Dobšiná,2663,6,0.0023,,,,,,,,,,,,
+Košický,Rožňava,Drnava,491,0,0,,,,,,,,,,,,
+Košický,Rožňava,Gemerská Hôrka,815,0,0,,,,,,,,,,,,
+Košický,Rožňava,Gemerská Panica,654,3,0.0046,,,,,,,,,,,,
+Košický,Rožňava,Gemerská Poloma,1229,3,0.0024,,,,,,,,,,,,
+Košický,Rožňava,Gočaltovo,302,0,0,,,,,,,,,,,,
+Košický,Rožňava,Gočovo,200,0,0,,,,,,,,,,,,
+Košický,Rožňava,Hanková,134,0,0,,,,,,,,,,,,
+Košický,Rožňava,Henkovce,313,1,0.0032,,,,,,,,,,,,
+Košický,Rožňava,Honce,189,1,0.0053,,,,,,,,,,,,
+Košický,Rožňava,Hrhov,667,3,0.0045,,,,,,,,,,,,
+Košický,Rožňava,Hrušov,285,1,0.0035,,,,,,,,,,,,
+Košický,Rožňava,Jablonov nad Turňou,548,3,0.0055,,,,,,,,,,,,
+Košický,Rožňava,Jovice,524,1,0.0019,,,,,,,,,,,,
+Košický,Rožňava,Kečovo,218,0,0,,,,,,,,,,,,
+Košický,Rožňava,Kobeliarovo,242,1,0.0041,,,,,,,,,,,,
+Košický,Rožňava,Koceľovce,130,0,0,,,,,,,,,,,,
+Košický,Rožňava,Kováčová,164,1,0.0061,,,,,,,,,,,,
+Košický,Rožňava,Krásnohorská Dlhá Lúka,499,0,0,,,,,,,,,,,,
+Košický,Rožňava,Krásnohorské Podhradie,1603,3,0.0019,,,,,,,,,,,,
+Košický,Rožňava,Kružná,304,0,0,,,,,,,,,,,,
+Košický,Rožňava,Kunova Teplica,423,0,0,,,,,,,,,,,,
+Košický,Rožňava,Lipovník,390,0,0,,,,,,,,,,,,
+Košický,Rožňava,Lúčka,194,0,0,,,,,,,,,,,,
+Košický,Rožňava,Markuška,266,0,0,,,,,,,,,,,,
+Košický,Rožňava,Nižná Slaná,807,12,0.0149,,,,121,2,0.0165,99,0,0,22,2,0.0909
+Košický,Rožňava,Ochtiná,359,0,0,,,,,,,,,,,,
+Košický,Rožňava,Pača,422,5,0.0118,,,,107,5,0.0467,77,0,0,30,5,0.1667
+Košický,Rožňava,Pašková,209,0,0,,,,,,,,,,,,
+Košický,Rožňava,Petrovo,65,0,0,,,,,,,,,,,,
+Košický,Rožňava,Plešivec,1100,0,0,,,,,,,,,,,,
+Košický,Rožňava,Rakovnica,433,2,0.0046,,,,,,,,,,,,
+Košický,Rožňava,Rejdová,582,3,0.0052,,,,,,,,,,,,
+Košický,Rožňava,Rochovce,185,0,0,,,,,,,,,,,,
+Košický,Rožňava,Roštár,301,4,0.0133,,,,62,3,0.0484,44,0,0,18,3,0.1667
+Košický,Rožňava,Rozložná,127,0,0,,,,,,,,,,,,
+Košický,Rožňava,Rožňava,7940,14,0.0018,,,,,,,,,,,,
+Košický,Rožňava,Rožňavské Bystré,403,3,0.0074,,,,,,,,,,,,
+Košický,Rožňava,Rudná,567,11,0.0194,,,,,,,,,,,,
+Košický,Rožňava,Silica,307,0,0,,,,,,,,,,,,
+Košický,Rožňava,Silická Brezová,86,0,0,,,,,,,,,,,,
+Košický,Rožňava,Silická Jablonica,139,0,0,,,,,,,,,,,,
+Košický,Rožňava,Slavec + Vidová,270,0,0,,,,,,,,,,,,
+Košický,Rožňava,Slavoška,65,2,0.0308,,,,25,0,0,14,0,0,11,0,0
+Košický,Rožňava,Slavošovce,884,1,0.0011,,,,,,,,,,,,
+Košický,Rožňava,Stratená,115,0,0,,,,,,,,,,,,
+Košický,Rožňava,Štítnik,657,1,0.0015,,,,,,,,,,,,
+Košický,Rožňava,Vlachovo,497,7,0.0141,,,,157,4,0.0255,99,0,0,58,4,0.069
+Košický,Rožňava,Vyšná Slaná,250,0,0,,,,,,,,,,,,
+Košický,Sobrance,Bežovce,501,5,0.01,518,3,0.0058,,,,,,,,,
+Košický,Sobrance,Blatné Remety,306,0,0,313,1,0.0032,,,,,,,,,
+Košický,Sobrance,Blatné Revištia,190,0,0,199,0,0,,,,,,,,,
+Košický,Sobrance,Bunkovce,302,1,0.0033,293,0,0,,,,,,,,,
+Košický,Sobrance,Fekišovce,209,5,0.0239,185,0,0,,,,,,,,,
+Košický,Sobrance,Hlivištia,393,13,0.0331,399,10,0.0251,135,3,0.0222,83,1,0.012,52,2,0.0385
+Košický,Sobrance,Horňa,312,7,0.0224,291,1,0.0034,,,,,,,,,
+Košický,Sobrance,Choňkovce,579,10,0.0173,561,1,0.0018,,,,,,,,,
+Košický,Sobrance,Jasenov,434,4,0.0092,416,0,0,,,,,,,,,
+Košický,Sobrance,Jenkovce,372,8,0.0215,364,0,0,,,,,,,,,
+Košický,Sobrance,Koromľa,378,5,0.0132,348,0,0,,,,,,,,,
+Košický,Sobrance,Krčava,578,5,0.0087,562,2,0.0036,,,,,,,,,
+Košický,Sobrance,Kristy,271,2,0.0074,271,1,0.0037,,,,,,,,,
+Košický,Sobrance,Lekárovce,552,5,0.0091,531,2,0.0038,,,,,,,,,
+Košický,Sobrance,Nižná Rybnica,265,10,0.0377,256,2,0.0078,,,,,,,,,
+Košický,Sobrance,Nižné Nemecké,404,8,0.0198,394,1,0.0025,,,,,,,,,
+Košický,Sobrance,Ostrov,380,5,0.0132,361,0,0,,,,,,,,,
+Košický,Sobrance,Podhoroď,402,4,0.01,401,2,0.005,,,,,,,,,
+Košický,Sobrance,Porúbka,515,1,0.0019,527,0,0,,,,,,,,,
+Košický,Sobrance,Remetské Hámre,557,0,0,570,0,0,,,,,,,,,
+Košický,Sobrance,Ruský Hrabovec,261,0,0,285,0,0,,,,,,,,,
+Košický,Sobrance,Sobrance,2691,22,0.0082,2742,9,0.0033,,,,,,,,,
+Košický,Sobrance,Tibava,468,1,0.0021,496,0,0,,,,,,,,,
+Košický,Sobrance,Úbrež,470,9,0.0191,447,4,0.0089,,,,,,,,,
+Košický,Sobrance,Veľké Revištia,339,0,0,352,2,0.0057,,,,,,,,,
+Košický,Sobrance,Vyšné Remety,436,2,0.0046,442,2,0.0045,,,,,,,,,
+Košický,Sobrance,Záhor,421,3,0.0071,442,0,0,,,,,,,,,
+Košický,Spišská Nová Ves,Arnutovce,729,19,0.0261,605,5,0.0083,,,,,,,,,
+Košický,Spišská Nová Ves,Betlanovce,500,6,0.012,448,9,0.0201,153,8,0.0523,105,6,0.0571,48,2,0.0417
+Košický,Spišská Nová Ves,Bystrany,1038,8,0.0077,946,7,0.0074,,,,,,,,,
+Košický,Spišská Nová Ves,Danišovce,570,3,0.0053,477,1,0.0021,,,,,,,,,
+Košický,Spišská Nová Ves,Harichovce,1932,20,0.0104,1620,7,0.0043,,,,,,,,,
+Košický,Spišská Nová Ves,Hincovce,131,4,0.0305,147,1,0.0068,,,,,,,,,
+Košický,Spišská Nová Ves,Hnilčík,392,8,0.0204,437,4,0.0092,,,,,,,,,
+Košický,Spišská Nová Ves,Hnilec,418,2,0.0048,407,0,0,,,,,,,,,
+Košický,Spišská Nová Ves,Hrabušice,1548,48,0.031,1474,26,0.0176,321,4,0.0125,278,4,0.0144,43,0,0
+Košický,Spišská Nová Ves,Chrasť nad Hornádom,617,15,0.0243,557,4,0.0072,,,,,,,,,
+Košický,Spišská Nová Ves,Iliašovce,741,10,0.0135,631,7,0.0111,264,5,0.0189,215,3,0.014,49,2,0.0408
+Košický,Spišská Nová Ves,Jamník,684,7,0.0102,735,5,0.0068,,,,,,,,,
+Košický,Spišská Nová Ves,Kaľava,182,0,0,187,0,0,,,,,,,,,
+Košický,Spišská Nová Ves,Kolinovce,496,5,0.0101,523,2,0.0038,,,,,,,,,
+Košický,Spišská Nová Ves,Krompachy,4324,39,0.009,4165,15,0.0036,,,,,,,,,
+Košický,Spišská Nová Ves,Letanovce,1178,49,0.0416,1356,15,0.0111,859,6,0.007,816,4,0.0049,43,2,0.0465
+Košický,Spišská Nová Ves,Lieskovany,350,11,0.0314,273,1,0.0037,,,,,,,,,
+Košický,Spišská Nová Ves,Markušovce,2253,23,0.0102,2311,11,0.0048,,,,,,,,,
+Košický,Spišská Nová Ves,Matejovce nad Hornádom,308,0,0,322,0,0,,,,,,,,,
+Košický,Spišská Nová Ves,Mlynky,435,4,0.0092,956,6,0.0063,,,,,,,,,
+Košický,Spišská Nová Ves,Odorín,854,3,0.0035,791,4,0.0051,,,,,,,,,
+Košický,Spišská Nová Ves,Olcnava,669,2,0.003,674,2,0.003,,,,,,,,,
+Košický,Spišská Nová Ves,Oľšavka,131,0,0,151,1,0.0066,,,,,,,,,
+Košický,Spišská Nová Ves,Poráč,660,5,0.0076,626,3,0.0048,,,,,,,,,
+Košický,Spišská Nová Ves,Rudňany,2440,19,0.0078,2186,3,0.0014,,,,,,,,,
+Košický,Spišská Nová Ves,Slatvina,319,4,0.0125,276,0,0,,,,,,,,,
+Košický,Spišská Nová Ves,Slovinky,1001,6,0.006,1039,2,0.0019,,,,,,,,,
+Košický,Spišská Nová Ves,Smižany,4755,94,0.0198,4536,44,0.0097,,,,,,,,,
+Košický,Spišská Nová Ves,Spišská Nová Ves,17585,215,0.0122,18500,110,0.0059,,,,,,,,,
+Košický,Spišská Nová Ves,Spišské Tomášovce,1260,25,0.0198,1212,14,0.0116,348,3,0.0086,273,2,0.0073,75,1,0.0133
+Košický,Spišská Nová Ves,Spišské Vlachy,1549,18,0.0116,1821,21,0.0115,720,16,0.0222,602,11,0.0183,118,5,0.0424
+Košický,Spišská Nová Ves,Spišský Hrušov,923,6,0.0065,930,7,0.0075,,,,,,,,,
+Košický,Spišská Nová Ves,Teplička,906,10,0.011,977,2,0.002,,,,,,,,,
+Košický,Spišská Nová Ves,Vítkovce,386,13,0.0337,316,14,0.0443,118,3,0.0254,93,2,0.0215,25,1,0.04
+Košický,Spišská Nová Ves,Vojkovce,221,2,0.009,219,2,0.0091,,,,,,,,,
+Košický,Spišská Nová Ves,Žehra,1491,35,0.0235,881,6,0.0068,,,,,,,,,
+Košický,Trebišov,Bačka,460,6,0.013,,,,279,9,0.0323,205,6,0.0293,74,3,0.0405
+Košický,Trebišov,Bačkov,493,1,0.002,,,,,,,,,,,,
+Košický,Trebišov,Bara,120,0,0,,,,,,,,,,,,
+Košický,Trebišov,Biel,805,8,0.0099,,,,,,,,,,,,
+Košický,Trebišov,Boľ,492,3,0.0061,,,,,,,,,,,,
+Košický,Trebišov,Borša,659,1,0.0015,,,,,,,,,,,,
+Košický,Trebišov,Boťany,779,7,0.009,,,,,,,,,,,,
+Košický,Trebišov,Brehov,398,4,0.0101,,,,51,0,0,44,0,0,7,0,0
+Košický,Trebišov,Brezina,466,1,0.0021,,,,,,,,,,,,
+Košický,Trebišov,Byšta,85,0,0,,,,,,,,,,,,
+Košický,Trebišov,Cejkov,634,0,0,,,,,,,,,,,,
+Košický,Trebišov,Čeľovce,770,3,0.0039,,,,,,,,,,,,
+Košický,Trebišov,Čerhov,441,4,0.0091,,,,,,,,,,,,
+Košický,Trebišov,Černochov,248,0,0,,,,,,,,,,,,
+Košický,Trebišov,Čierna,182,0,0,,,,,,,,,,,,
+Košický,Trebišov,Čierna nad Tisou,1963,15,0.0076,,,,,,,,,,,,
+Košický,Trebišov,Dargov,416,6,0.0144,,,,114,0,0,79,0,0,35,0,0
+Košický,Trebišov,Dobrá,397,5,0.0126,,,,113,3,0.0265,65,3,0.0462,48,0,0
+Košický,Trebišov,Dvorianky,323,0,0,,,,,,,,,,,,
+Košický,Trebišov,Egreš,228,1,0.0044,,,,,,,,,,,,
+Košický,Trebišov,Hraň,723,8,0.0111,,,,120,0,0,101,0,0,19,0,0
+Košický,Trebišov,Hrčeľ,521,11,0.0211,,,,254,0,0,215,0,0,39,0,0
+Košický,Trebišov,Hriadky,177,2,0.0113,,,,54,0,0,39,0,0,15,0,0
+Košický,Trebišov,Kašov,121,0,0,,,,,,,,,,,,
+Košický,Trebišov,Kazimír,610,4,0.0066,,,,,,,,,,,,
+Košický,Trebišov,Klin nad Bodrogom,315,4,0.0127,,,,70,0,0,45,0,0,25,0,0
+Košický,Trebišov,Kožuchov,226,0,0,,,,,,,,,,,,
+Košický,Trebišov,Kráľovský Chlmec,3700,13,0.0035,,,,,,,,,,,,
+Košický,Trebišov,Kravany,272,2,0.0074,,,,,,,,,,,,
+Košický,Trebišov,Kuzmice,994,6,0.006,,,,,,,,,,,,
+Košický,Trebišov,Kysta,335,2,0.006,,,,,,,,,,,,
+Košický,Trebišov,Ladmovce,286,2,0.007,,,,,,,,,,,,
+Košický,Trebišov,Lastovce,654,7,0.0107,,,,209,0,0,186,0,0,23,0,0
+Košický,Trebišov,Leles,489,3,0.0061,,,,,,,,,,,,
+Košický,Trebišov,Leles 1 - Leles3,538,2,0.0037,,,,,,,,,,,,
+Košický,Trebišov,Luhyňa,289,0,0,,,,,,,,,,,,
+Košický,Trebišov,Malá Tŕňa,176,2,0.0114,,,,62,0,0,52,0,0,10,0,0
+Košický,Trebišov,Malé Ozorovce,325,2,0.0062,,,,,,,,,,,,
+Košický,Trebišov,Malé Trakany,676,4,0.0059,,,,,,,,,,,,
+Košický,Trebišov,Malý Horeš,750,0,0,,,,,,,,,,,,
+Košický,Trebišov,Malý Kamenec,310,2,0.0065,,,,,,,,,,,,
+Košický,Trebišov,Michaľany,1003,9,0.009,,,,,,,,,,,,
+Košický,Trebišov,Nižný Žipov,787,2,0.0025,,,,,,,,,,,,
+Košický,Trebišov,Novosad,525,4,0.0076,,,,,,,,,,,,
+Košický,Trebišov,Nový Ruskov,498,1,0.002,,,,,,,,,,,,
+Košický,Trebišov,Parchovany,1096,11,0.01,,,,301,1,0.0033,231,0,0,70,1,0.0143
+Košický,Trebišov,Plechotice,528,2,0.0038,,,,,,,,,,,,
+Košický,Trebišov,Poľany,191,0,0,,,,,,,,,,,,
+Košický,Trebišov,Pribeník,619,3,0.0048,,,,,,,,,,,,
+Košický,Trebišov,Rad,450,1,0.0022,,,,,,,,,,,,
+Košický,Trebišov,Sečovce,3486,23,0.0066,,,,339,3,0.0088,259,1,0.0039,80,2,0.025
+Košický,Trebišov,Sirník,389,1,0.0026,,,,,,,,,,,,
+Košický,Trebišov,Slivník,497,11,0.0221,,,,115,0,0,101,0,0,14,0,0
+Košický,Trebišov,Slovenské Nové Mesto,759,3,0.004,,,,,,,,,,,,
+Košický,Trebišov,Soľnička,220,0,0,,,,,,,,,,,,
+Košický,Trebišov,Somotor,665,4,0.006,,,,,,,,,,,,
+Košický,Trebišov,Stanča,354,2,0.0056,,,,,,,,,,,,
+Košický,Trebišov,Stankovce,218,0,0,,,,,,,,,,,,
+Košický,Trebišov,Strážne,417,2,0.0048,,,,,,,,,,,,
+Košický,Trebišov,Streda nad Bodrogom,1163,5,0.0043,,,,,,,,,,,,
+Košický,Trebišov,Svätá Mária,351,0,0,,,,,,,,,,,,
+Košický,Trebišov,Svätuše,539,1,0.0019,,,,,,,,,,,,
+Košický,Trebišov,Svinice,306,0,0,,,,,,,,,,,,
+Košický,Trebišov,Trebišov,14691,58,0.0039,,,,,,,,,,,,
+Košický,Trebišov,Trnávka,186,0,0,,,,,,,,,,,,
+Košický,Trebišov,Veľaty,459,0,0,,,,,,,,,,,,
+Košický,Trebišov,Veľká Tŕňa,391,4,0.0102,,,,80,0,0,71,0,0,9,0,0
+Košický,Trebišov,Veľké Ozorovce,447,4,0.0089,,,,,,,,,,,,
+Košický,Trebišov,Veľké Trakany,767,1,0.0013,,,,,,,,,,,,
+Košický,Trebišov,Veľký Horeš,601,5,0.0083,,,,,,,,,,,,
+Košický,Trebišov,Veľký Kamenec,474,1,0.0021,,,,,,,,,,,,
+Košický,Trebišov,Viničky,249,1,0.004,,,,,,,,,,,,
+Košický,Trebišov,Višňov,81,0,0,,,,,,,,,,,,
+Košický,Trebišov,Vojčice,1058,6,0.0057,,,,,,,,,,,,
+Košický,Trebišov,Vojka,322,0,0,,,,,,,,,,,,
+Košický,Trebišov,Zatín,377,3,0.008,,,,,,,,,,,,
+Košický,Trebišov,Zbehňov,193,0,0,,,,,,,,,,,,
+Košický,Trebišov,Zemplín,219,2,0.0091,,,,,,,,,,,,
+Košický,Trebišov,Zemplínska Nová Ves,673,1,0.0015,,,,,,,,,,,,
+Košický,Trebišov,Zemplínska Teplica,970,38,0.0392,,,,202,5,0.0248,185,5,0.027,17,0,0
+Košický,Trebišov,Zemplínske Hradište,542,1,0.0018,,,,,,,,,,,,
+Košický,Trebišov,Zemplínske Jastrabie,390,1,0.0026,,,,,,,,,,,,
+Košický,Trebišov,Zemplínsky Branč,300,1,0.0033,,,,,,,,,,,,
+Nitriansky,Komárno,Bajč,858,1,0.0012,,,,,,,,,,,,
+Nitriansky,Komárno,Bátorové Kosihy,2167,10,0.0046,,,,,,,,,,,,
+Nitriansky,Komárno,Bodza + Holiare + Lipové,861,14,0.0163,,,,165,0,0,127,0,0,38,0,0
+Nitriansky,Komárno,Bodzianské Lúky,484,0,0,,,,,,,,,,,,
+Nitriansky,Komárno,Búč,890,3,0.0034,,,,,,,,,,,,
+Nitriansky,Komárno,Čalovec,714,1,0.0014,,,,,,,,,,,,
+Nitriansky,Komárno,Číčov,774,4,0.0052,,,,,,,,,,,,
+Nitriansky,Komárno,Dedina Mládeže,315,0,0,,,,,,,,,,,,
+Nitriansky,Komárno,Dulovce,957,7,0.0073,,,,,,,,,,,,
+Nitriansky,Komárno,Hurbanovo,4600,44,0.0096,,,,,,,,,,,,
+Nitriansky,Komárno,Chotín,1082,3,0.0028,,,,,,,,,,,,
+Nitriansky,Komárno,Imeľ,1864,8,0.0043,,,,,,,,,,,,
+Nitriansky,Komárno,Iža,1146,10,0.0087,,,,,,,,,,,,
+Nitriansky,Komárno,Kameničná,1389,5,0.0036,,,,,,,,,,,,
+Nitriansky,Komárno,Kolárovo,6514,35,0.0054,,,,,,,,,,,,
+Nitriansky,Komárno,Komárno,18244,148,0.0081,,,,,,,,,,,,
+Nitriansky,Komárno,Kravany nad Dunajom,602,2,0.0033,,,,,,,,,,,,
+Nitriansky,Komárno,Marcelová,2506,7,0.0028,,,,,,,,,,,,
+Nitriansky,Komárno,Martovce,568,6,0.0106,,,,284,7,0.0246,232,3,0.0129,52,4,0.0769
+Nitriansky,Komárno,Moča,688,7,0.0102,,,,300,2,0.0067,239,1,0.0042,61,1,0.0164
+Nitriansky,Komárno,Modrany + Mudroňovo,873,7,0.008,,,,,,,,,,,,
+Nitriansky,Komárno,Nesvady,3355,21,0.0063,,,,,,,,,,,,
+Nitriansky,Komárno,Okoličná na Ostrove,968,7,0.0072,,,,,,,,,,,,
+Nitriansky,Komárno,Patince + Virt,765,2,0.0026,,,,,,,,,,,,
+Nitriansky,Komárno,Pribeta,1811,16,0.0088,,,,,,,,,,,,
+Nitriansky,Komárno,Radvaň nad Dunajom,697,7,0.01,,,,280,2,0.0071,220,0,0,60,2,0.0333
+Nitriansky,Komárno,Sokolce + Brestovec,1358,31,0.0228,,,,225,5,0.0222,188,4,0.0213,37,1,0.027
+Nitriansky,Komárno,Svätý Peter,1914,10,0.0052,,,,,,,,,,,,
+Nitriansky,Komárno,Šrobárová,290,0,0,,,,,,,,,,,,
+Nitriansky,Komárno,Tôň,715,6,0.0084,,,,,,,,,,,,
+Nitriansky,Komárno,Trávnik + Kližská Nemá,1030,3,0.0029,,,,,,,,,,,,
+Nitriansky,Komárno,Veľké Kosihy,1016,5,0.0049,,,,,,,,,,,,
+Nitriansky,Komárno,Vrbová nad Váhom,730,13,0.0178,,,,136,2,0.0147,93,1,0.0108,43,1,0.0233
+Nitriansky,Komárno,Zeminská Olča,1599,3,0.0019,,,,,,,,,,,,
+Nitriansky,Komárno,Zlatná na Ostrove,1843,11,0.006,,,,,,,,,,,,
+Nitriansky,Levice,Bátovce + Bohunice + Pečenice,1057,1,0.0009,,,,,,,,,,,,
+Nitriansky,Levice,Beša,570,2,0.0035,,,,,,,,,,,,
+Nitriansky,Levice,Čajkov,753,3,0.004,,,,,,,,,,,,
+Nitriansky,Levice,Čaka,566,3,0.0053,,,,,,,,,,,,
+Nitriansky,Levice,Čata,686,0,0,,,,,,,,,,,,
+Nitriansky,Levice,Demandice,691,1,0.0014,,,,,,,,,,,,
+Nitriansky,Levice,Dolná Seč + Vyšné nad Hronom,456,3,0.0066,,,,,,,,,,,,
+Nitriansky,Levice,Dolné Semerovce,204,0,0,,,,,,,,,,,,
+Nitriansky,Levice,Dolný Pial + Horný Pial,656,3,0.0046,,,,,,,,,,,,
+Nitriansky,Levice,Drženice,417,3,0.0072,,,,,,,,,,,,
+Nitriansky,Levice,Farná,879,3,0.0034,,,,,,,,,,,,
+Nitriansky,Levice,Hokovce,385,0,0,,,,,,,,,,,,
+Nitriansky,Levice,Hontianské Trsťany,197,5,0.0254,,,,109,2,0.0183,81,2,0.0247,28,0,0
+Nitriansky,Levice,Horná Seč,688,4,0.0058,,,,,,,,,,,,
+Nitriansky,Levice,Horné Semerovce + Slatina,522,10,0.0192,,,,103,3,0.0291,60,0,0,43,3,0.0698
+Nitriansky,Levice,Horné Túrovce,453,4,0.0088,,,,,,,,,,,,
+Nitriansky,Levice,Hotianská Vrbica,504,2,0.004,,,,,,,,,,,,
+Nitriansky,Levice,Hrkovce,227,1,0.0044,,,,,,,,,,,,
+Nitriansky,Levice,Hronovce + Malé Ludince + Šalov,659,2,0.003,,,,,,,,,,,,
+Nitriansky,Levice,Hronské Kľačany,854,2,0.0023,,,,,,,,,,,,
+Nitriansky,Levice,Hronské Kosihy,626,1,0.0016,,,,,,,,,,,,
+Nitriansky,Levice,Iňa + Jesenské,404,0,0,,,,,,,,,,,,
+Nitriansky,Levice,Ipeľské Úľany,243,2,0.0082,,,,,,,,,,,,
+Nitriansky,Levice,Ipeľský Sokolec,513,0,0,,,,,,,,,,,,
+Nitriansky,Levice,Jabloňovce,168,0,0,,,,,,,,,,,,
+Nitriansky,Levice,Jur nad Hronom + Žemliare,828,4,0.0048,,,,,,,,,,,,
+Nitriansky,Levice,Kalná nad Hronom,1449,14,0.0097,,,,,,,,,,,,
+Nitriansky,Levice,Keť,459,4,0.0087,,,,,,,,,,,,
+Nitriansky,Levice,Kozárovce,1178,12,0.0102,,,,216,4,0.0185,115,3,0.0261,101,1,0.0099
+Nitriansky,Levice,Krškany,666,1,0.0015,,,,,,,,,,,,
+Nitriansky,Levice,Kukučínov,427,0,0,,,,,,,,,,,,
+Nitriansky,Levice,Kuraľany,280,1,0.0036,,,,,,,,,,,,
+Nitriansky,Levice,Levice,16149,90,0.0056,,,,,,,,,,,,
+Nitriansky,Levice,Lok,458,3,0.0066,,,,,,,,,,,,
+Nitriansky,Levice,Lontov,437,0,0,,,,,,,,,,,,
+Nitriansky,Levice,Málaš,390,1,0.0026,,,,,,,,,,,,
+Nitriansky,Levice,Malé Kozmálovce,320,1,0.0031,,,,,,,,,,,,
+Nitriansky,Levice,Mýtne Ludany + Starý Hrádok,811,2,0.0025,,,,,,,,,,,,
+Nitriansky,Levice,Nová Dedina,778,6,0.0077,,,,,,,,,,,,
+Nitriansky,Levice,Nový Tekov,608,1,0.0016,,,,,,,,,,,,
+Nitriansky,Levice,Nýrovce,489,1,0.002,,,,,,,,,,,,
+Nitriansky,Levice,Ondrejovce + Bajka,483,1,0.0021,,,,,,,,,,,,
+Nitriansky,Levice,Pastovce + Bielovce,586,1,0.0017,,,,,,,,,,,,
+Nitriansky,Levice,Plášťovce,929,2,0.0022,,,,,,,,,,,,
+Nitriansky,Levice,Plavé Vozokany,434,5,0.0115,,,,113,0,0,89,0,0,24,0,0
+Nitriansky,Levice,Podlužany,446,4,0.009,,,,,,,,,,,,
+Nitriansky,Levice,Pohronský Ruskov,721,2,0.0028,,,,,,,,,,,,
+Nitriansky,Levice,Pukanec + Devičany,1206,7,0.0058,,,,,,,,,,,,
+Nitriansky,Levice,Rybník,841,3,0.0036,,,,,,,,,,,,
+Nitriansky,Levice,Santovka + Bory + Domadice,850,5,0.0059,,,,,,,,,,,,
+Nitriansky,Levice,Sazdice + Kubáňovo,311,0,0,,,,,,,,,,,,
+Nitriansky,Levice,Sikenica,619,1,0.0016,,,,,,,,,,,,
+Nitriansky,Levice,Starý Tekov,1196,4,0.0033,,,,,,,,,,,,
+Nitriansky,Levice,Šahy,3543,29,0.0082,,,,,,,,,,,,
+Nitriansky,Levice,Šarovce,1023,4,0.0039,,,,,,,,,,,,
+Nitriansky,Levice,Tehla + Lula,575,2,0.0035,,,,,,,,,,,,
+Nitriansky,Levice,Tekovské Lužany,1852,7,0.0038,,,,,,,,,,,,
+Nitriansky,Levice,Tekovský Hrádok + Turá,320,1,0.0031,,,,,,,,,,,,
+Nitriansky,Levice,Tlmače,2148,13,0.0061,,,,,,,,,,,,
+Nitriansky,Levice,Tupá,455,11,0.0242,,,,126,4,0.0317,40,0,0,86,4,0.0465
+Nitriansky,Levice,Uhliská,315,2,0.0063,,,,,,,,,,,,
+Nitriansky,Levice,Veľké Kozmálovce,638,3,0.0047,,,,,,,,,,,,
+Nitriansky,Levice,Veľké Ludince,799,6,0.0075,,,,,,,,,,,,
+Nitriansky,Levice,Veľké Turovce,551,1,0.0018,,,,,,,,,,,,
+Nitriansky,Levice,Veľký Ďur,910,3,0.0033,,,,,,,,,,,,
+Nitriansky,Levice,Vyškovce nad Ipľom,561,1,0.0018,,,,,,,,,,,,
+Nitriansky,Levice,Zbrojníky,640,4,0.0063,,,,,,,,,,,,
+Nitriansky,Levice,Želiezovce,3186,13,0.0041,,,,,,,,,,,,
+Nitriansky,Levice,Žemberovce + Brhlovce,1168,9,0.0077,,,,,,,,,,,,
+Nitriansky,Nitra,Alekšince,1014,24,0.0237,,,,258,4,0.0155,209,2,0.0096,49,2,0.0408
+Nitriansky,Nitra,Báb,845,1,0.0012,,,,,,,,,,,,
+Nitriansky,Nitra,Babindol,947,4,0.0042,,,,,,,,,,,,
+Nitriansky,Nitra,Bádice,536,0,0,,,,,,,,,,,,
+Nitriansky,Nitra,Branč,1508,12,0.008,,,,,,,,,,,,
+Nitriansky,Nitra,Cabaj - Čápor,2507,13,0.0052,,,,,,,,,,,,
+Nitriansky,Nitra,Čab,711,11,0.0155,,,,159,6,0.0377,101,3,0.0297,58,3,0.0517
+Nitriansky,Nitra,Čakajovce,744,3,0.004,,,,,,,,,,,,
+Nitriansky,Nitra,Čechynce,979,4,0.0041,,,,,,,,,,,,
+Nitriansky,Nitra,Čeľadice,767,2,0.0026,,,,,,,,,,,,
+Nitriansky,Nitra,Čifáre,395,5,0.0127,,,,181,9,0.0497,78,2,0.0256,103,7,0.068
+Nitriansky,Nitra,Dolné Lefantovce,1727,21,0.0122,,,,147,2,0.0136,81,0,0,66,2,0.0303
+Nitriansky,Nitra,Dolné Leftanovce,1727,21,0.0122,,,,,,,,,,,,
+Nitriansky,Nitra,Golianovo,1598,7,0.0044,,,,,,,,,,,,
+Nitriansky,Nitra,Horné Lefantovce,545,13,0.0239,,,,117,2,0.0171,108,2,0.0185,9,0,0
+Nitriansky,Nitra,Horné Leftanovce,545,13,0.0239,,,,,,,,,,,,
+Nitriansky,Nitra,Hosťová,261,0,0,,,,,,,,,,,,
+Nitriansky,Nitra,Hruboňovo,492,11,0.0224,,,,77,0,0,62,0,0,15,0,0
+Nitriansky,Nitra,Ivanka pri Nitre,1946,20,0.0103,,,,650,16,0.0246,329,3,0.0091,321,13,0.0405
+Nitriansky,Nitra,Jarok,1745,18,0.0103,,,,398,9,0.0226,285,4,0.014,113,5,0.0442
+Nitriansky,Nitra,Jelenec,1603,18,0.0112,,,,450,11,0.0244,330,2,0.0061,120,9,0.075
+Nitriansky,Nitra,Jelšovce,845,8,0.0095,,,,,,,,,,,,
+Nitriansky,Nitra,Kapince,341,4,0.0117,,,,37,0,0,22,0,0,15,0,0
+Nitriansky,Nitra,Klasov,815,3,0.0037,,,,,,,,,,,,
+Nitriansky,Nitra,Kolíňany,1026,10,0.0097,,,,,,,,,,,,
+Nitriansky,Nitra,Lehota,1766,8,0.0045,,,,,,,,,,,,
+Nitriansky,Nitra,Lúčnica nad Žitavou,644,3,0.0047,,,,,,,,,,,,
+Nitriansky,Nitra,Ľudovítová,116,1,0.0086,,,,,,,,,,,,
+Nitriansky,Nitra,Lukáčovce,826,4,0.0048,,,,,,,,,,,,
+Nitriansky,Nitra,Lužianky,1288,10,0.0078,,,,,,,,,,,,
+Nitriansky,Nitra,Malé Chyndice,463,0,0,,,,,,,,,,,,
+Nitriansky,Nitra,Malé Zálužie,182,4,0.022,,,,75,0,0,55,0,0,20,0,0
+Nitriansky,Nitra,Malý Cetín,525,2,0.0038,,,,,,,,,,,,
+Nitriansky,Nitra,Malý Lapáš,766,7,0.0091,,,,,,,,,,,,
+Nitriansky,Nitra,Melek,326,1,0.0031,,,,,,,,,,,,
+Nitriansky,Nitra,Mojmírovce,1901,2,0.0011,,,,,,,,,,,,
+Nitriansky,Nitra,Nitra,44219,258,0.0058,,,,,,,,,,,,
+Nitriansky,Nitra,Nitrianske,1669,13,0.0078,,,,,,,,,,,,
+Nitriansky,Nitra,Nová Ves nad Žitavou,834,6,0.0072,,,,,,,,,,,,
+Nitriansky,Nitra,Nové Sady,820,4,0.0049,,,,,,,,,,,,
+Nitriansky,Nitra,Paňa,269,0,0,,,,,,,,,,,,
+Nitriansky,Nitra,Podhorany,782,7,0.009,,,,,,,,,,,,
+Nitriansky,Nitra,Pohranice,855,4,0.0047,,,,,,,,,,,,
+Nitriansky,Nitra,Poľný Kesov,655,2,0.0031,,,,,,,,,,,,
+Nitriansky,Nitra,Rišňovce,1533,6,0.0039,,,,,,,,,,,,
+Nitriansky,Nitra,Rumanová,758,2,0.0026,,,,,,,,,,,,
+Nitriansky,Nitra,Svätoplukovo,1024,7,0.0068,,,,,,,,,,,,
+Nitriansky,Nitra,Štefanovičová,175,1,0.0057,,,,,,,,,,,,
+Nitriansky,Nitra,Štitáre,855,4,0.0047,,,,,,,,,,,,
+Nitriansky,Nitra,Šurianky,690,5,0.0072,,,,,,,,,,,,
+Nitriansky,Nitra,Tajná,360,7,0.0194,,,,87,7,0.0805,36,1,0.0278,51,6,0.1176
+Nitriansky,Nitra,Telince,359,1,0.0028,,,,,,,,,,,,
+Nitriansky,Nitra,Veľká Dolina,597,4,0.0067,,,,,,,,,,,,
+Nitriansky,Nitra,Veľké Chyndice,147,1,0.0068,,,,,,,,,,,,
+Nitriansky,Nitra,Veľké Zálužie,2118,25,0.0118,,,,620,5,0.0081,494,3,0.0061,126,2,0.0159
+Nitriansky,Nitra,Veľký Cetín,1007,1,0.001,,,,,,,,,,,,
+Nitriansky,Nitra,Veľký Lapáš,874,2,0.0023,,,,,,,,,,,,
+Nitriansky,Nitra,Vinodol,1643,7,0.0043,,,,,,,,,,,,
+Nitriansky,Nitra,Vráble,5574,30,0.0054,,,,,,,,,,,,
+Nitriansky,Nitra,Výčapy,1481,9,0.0061,,,,,,,,,,,,
+Nitriansky,Nitra,Zbehy,1650,19,0.0115,,,,350,12,0.0343,206,6,0.0291,144,6,0.0417
+Nitriansky,Nitra,Zlatno,124,0,0,,,,,,,,,,,,
+Nitriansky,Nitra,Žirany,926,23,0.0248,,,,327,8,0.0245,255,3,0.0118,72,5,0.0694
+Nitriansky,Nitra,Žitavce,441,2,0.0045,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Andovce,1062,6,0.0056,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Bajtava,243,0,0,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Bánov,2253,6,0.0027,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Bardoňovo + Pozba,613,3,0.0049,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Belá + Ľubá,697,3,0.0043,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Bešeňov,1475,4,0.0027,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Bíňa,798,4,0.005,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Branovo,761,3,0.0039,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Bruty,462,2,0.0043,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Čechy,206,0,0,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Černík,811,0,0,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Dedinka,574,4,0.007,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Dolný Ohaj,1158,8,0.0069,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Dubník,983,3,0.0031,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Dvory n/Žitavou,3234,9,0.0028,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Gbelce,1384,5,0.0036,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Hul + Vlkas,872,4,0.0046,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Jasová,809,3,0.0037,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Jatov,498,4,0.008,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Kamenica n/Hronom,1271,1,0.0008,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Kamenín,762,5,0.0066,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Kamenný Most,913,6,0.0066,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Kmeťovo,585,3,0.0051,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Kolta,853,6,0.007,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Komjatice,2493,3,0.0012,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Komoča,888,4,0.0045,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Leľa,169,0,0,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Lipová,1062,3,0.0028,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Malá n/Hronom,471,9,0.0191,,,,182,5,0.0275,78,1,0.0128,104,4,0.0385
+Nitriansky,Nové Zámky,Malé Kosihy,268,2,0.0075,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Maňa,1490,5,0.0034,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Michal n/Žitavou,764,3,0.0039,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Mojzesovo,913,14,0.0153,,,,259,4,0.0154,187,0,0,72,4,0.0556
+Nitriansky,Nové Zámky,Mužla,1425,10,0.007,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Nána,826,6,0.0073,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Nová Vieska,643,1,0.0016,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Nové Zámky,18549,97,0.0052,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Obid,834,2,0.0024,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Palárikovo,2475,12,0.0048,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Podhájska,727,15,0.0206,,,,225,7,0.0311,140,1,0.0071,85,6,0.0706
+Nitriansky,Nové Zámky,Radava,647,4,0.0062,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Rastislavice,720,4,0.0056,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Rúbaň,577,1,0.0017,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Salka,604,5,0.0083,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Semerovo,897,4,0.0045,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Sikenička + Pavlová,624,2,0.0032,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Strekov,1184,10,0.0084,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Svodín,1488,1,0.0007,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Šarkan,216,0,0,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Štúrovo,4554,23,0.0051,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Šurany,6186,70,0.0113,,,,1025,48,0.0468,633,11,0.0174,392,37,0.0944
+Nitriansky,Nové Zámky,Trávnica,770,2,0.0026,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Tvrdošovce,2411,12,0.005,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Úľany nad Žitavou,1076,4,0.0037,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Veľké Lovce,1035,4,0.0039,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Veľký Kýr,1888,9,0.0048,,,,,,,,,,,,
+Nitriansky,Nové Zámky,Zemné,1073,3,0.0028,,,,,,,,,,,,
+Nitriansky,Šaľa,Diakovce,2182,12,0.0055,,,,,,,,,,,,
+Nitriansky,Šaľa,Dlhá,646,9,0.0139,,,,434,15,0.0346,263,0,0,171,15,0.0877
+Nitriansky,Šaľa,Hájske,793,6,0.0076,,,,,,,,,,,,
+Nitriansky,Šaľa,Horná Kráľová,1206,9,0.0075,,,,,,,,,,,,
+Nitriansky,Šaľa,Kráľová nad Váhom,1028,8,0.0078,,,,,,,,,,,,
+Nitriansky,Šaľa,Močenok,2045,25,0.0122,,,,571,6,0.0105,473,3,0.0063,98,3,0.0306
+Nitriansky,Šaľa,Neded,2038,10,0.0049,,,,,,,,,,,,
+Nitriansky,Šaľa,Selice,1431,21,0.0147,,,,232,5,0.0216,198,0,0,34,5,0.1471
+Nitriansky,Šaľa,Šaľa,12632,53,0.0042,,,,,,,,,,,,
+Nitriansky,Šaľa,Tešedíkovo,2449,20,0.0082,,,,,,,,,,,,
+Nitriansky,Šaľa,Trnovec,2299,8,0.0035,,,,,,,,,,,,
+Nitriansky,Šaľa,Vlčany,2234,12,0.0054,,,,,,,,,,,,
+Nitriansky,Šaľa,Žihárec,1010,6,0.0059,,,,,,,,,,,,
+Nitriansky,Topoľčany,Blesovce,196,4,0.0204,216,0,0,,,,,,,,,
+Nitriansky,Topoľčany,Bojná,1326,38,0.0287,1300,6,0.0046,,,,,,,,,
+Nitriansky,Topoľčany,Bzince,242,4,0.0165,113,0,0,,,,,,,,,
+Nitriansky,Topoľčany,Čeľadince,415,10,0.0241,387,0,0,,,,,,,,,
+Nitriansky,Topoľčany,Čermany,187,4,0.0214,312,3,0.0096,,,,,,,,,
+Nitriansky,Topoľčany,Dvorany nad Nitrou,596,6,0.0101,735,6,0.0082,,,,,,,,,
+Nitriansky,Topoľčany,Hajná Nová Ves,452,7,0.0155,400,4,0.01,43,0,0,40,0,0,3,0,0
+Nitriansky,Topoľčany,Hajnej Novej Vsi,452,7,0.0155,400,4,0.01,,,,,,,,,
+Nitriansky,Topoľčany,Horné Chlebany,162,2,0.0123,176,0,0,,,,,,,,,
+Nitriansky,Topoľčany,Horné Obdokovce,682,27,0.0396,818,2,0.0024,,,,,,,,,
+Nitriansky,Topoľčany,Horné Štitáre,576,15,0.026,624,3,0.0048,,,,,,,,,
+Nitriansky,Topoľčany,Hrušovany,764,11,0.0144,1368,18,0.0132,95,1,0.0105,50,0,0,45,1,0.0222
+Nitriansky,Topoľčany,Chrabrany,682,10,0.0147,673,8,0.0119,90,1,0.0111,56,0,0,34,1,0.0294
+Nitriansky,Topoľčany,Jacovce,937,15,0.016,1052,4,0.0038,,,,,,,,,
+Nitriansky,Topoľčany,Kamanová,666,11,0.0165,873,3,0.0034,,,,,,,,,
+Nitriansky,Topoľčany,Koniarovce,607,6,0.0099,1343,9,0.0067,,,,,,,,,
+Nitriansky,Topoľčany,Kovarce,789,16,0.0203,969,6,0.0062,,,,,,,,,
+Nitriansky,Topoľčany,Krnča,895,14,0.0156,908,7,0.0077,,,,,,,,,
+Nitriansky,Topoľčany,Krtovce,329,8,0.0243,305,6,0.0197,37,0,0,23,0,0,14,0,0
+Nitriansky,Topoľčany,Krušovce,885,13,0.0147,929,3,0.0032,,,,,,,,,
+Nitriansky,Topoľčany,Kuzmice,597,8,0.0134,400,2,0.005,,,,,,,,,
+Nitriansky,Topoľčany,Lipovník,194,5,0.0258,215,0,0,,,,,,,,,
+Nitriansky,Topoľčany,Ludanice,1019,17,0.0167,1198,5,0.0042,,,,,,,,,
+Nitriansky,Topoľčany,Malé Ripňany,690,5,0.0072,1037,11,0.0106,117,7,0.0598,47,2,0.0426,70,5,0.0714
+Nitriansky,Topoľčany,Nemčice,663,15,0.0226,710,8,0.0113,224,7,0.0313,139,1,0.0072,85,6,0.0706
+Nitriansky,Topoľčany,Nemečky,204,1,0.0049,229,1,0.0044,,,,,,,,,
+Nitriansky,Topoľčany,Nitrianska Blatnica,730,6,0.0082,864,7,0.0081,,,,,,,,,
+Nitriansky,Topoľčany,Nitrianska Streda,547,3,0.0055,620,3,0.0048,,,,,,,,,
+Nitriansky,Topoľčany,Norovce,436,5,0.0115,422,2,0.0047,,,,,,,,,
+Nitriansky,Topoľčany,Oponice,495,6,0.0121,933,10,0.0107,70,2,0.0286,44,0,0,26,2,0.0769
+Nitriansky,Topoľčany,Orešany,315,0,0,312,1,0.0032,,,,,,,,,
+Nitriansky,Topoľčany,Podhradie,175,3,0.0171,198,0,0,,,,,,,,,
+Nitriansky,Topoľčany,Prašice,1340,18,0.0134,1375,10,0.0073,,,,,,,,,
+Nitriansky,Topoľčany,Práznovce,687,9,0.0131,693,4,0.0058,,,,,,,,,
+Nitriansky,Topoľčany,Preseľany,854,9,0.0105,1390,8,0.0058,,,,,,,,,
+Nitriansky,Topoľčany,Radošina,1206,8,0.0066,1710,7,0.0041,,,,,,,,,
+Nitriansky,Topoľčany,Rajčany,472,3,0.0064,454,7,0.0154,143,8,0.0559,80,1,0.0125,63,7,0.1111
+Nitriansky,Topoľčany,Solčany,1591,29,0.0182,1578,12,0.0076,,,,,,,,,
+Nitriansky,Topoľčany,Súlovce,429,7,0.0163,615,3,0.0049,,,,,,,,,
+Nitriansky,Topoľčany,Šalgovce,559,4,0.0072,884,8,0.009,,,,,,,,,
+Nitriansky,Topoľčany,Tesáre,524,7,0.0134,489,1,0.002,,,,,,,,,
+Nitriansky,Topoľčany,Topoľčany,13874,240,0.0173,14242,89,0.0062,,,,,,,,,
+Nitriansky,Topoľčany,Tovarníky,968,24,0.0248,932,7,0.0075,,,,,,,,,
+Nitriansky,Topoľčany,Tvrdomestice,242,10,0.0413,260,3,0.0115,70,3,0.0429,47,0,0,23,3,0.1304
+Nitriansky,Topoľčany,Urmince,690,18,0.0261,779,6,0.0077,,,,,,,,,
+Nitriansky,Topoľčany,Veľké Bedzany,504,9,0.0179,522,2,0.0038,,,,,,,,,
+Nitriansky,Topoľčany,Veľké Dvorany,608,17,0.028,583,7,0.012,118,7,0.0593,80,5,0.0625,38,2,0.0526
+Nitriansky,Topoľčany,Veľké Ripňany,1380,19,0.0138,1812,9,0.005,,,,,,,,,
+Nitriansky,Topoľčany,Velušovce,439,6,0.0137,458,1,0.0022,,,,,,,,,
+Nitriansky,Topoľčany,Vozokany,342,2,0.0058,353,1,0.0028,,,,,,,,,
+Nitriansky,Topoľčany,Závada,515,14,0.0272,485,1,0.0021,,,,,,,,,
+Nitriansky,Zlaté Moravce,Beladice,1142,2,0.0018,,,,,,,,,,,,
+Nitriansky,Zlaté Moravce,Čaradice,300,1,0.0033,,,,,,,,,,,,
+Nitriansky,Zlaté Moravce,Červený Hrádok,373,2,0.0054,,,,,,,,,,,,
+Nitriansky,Zlaté Moravce,Čierne Kľačany,712,4,0.0056,,,,,,,,,,,,
+Nitriansky,Zlaté Moravce,Hostie,794,11,0.0139,,,,186,3,0.0161,160,2,0.0125,26,1,0.0385
+Nitriansky,Zlaté Moravce,Hosťovce,634,3,0.0047,,,,,,,,,,,,
+Nitriansky,Zlaté Moravce,Choča,562,3,0.0053,,,,,,,,,,,,
+Nitriansky,Zlaté Moravce,Jedľové Kostoľany,694,11,0.0159,,,,109,0,0,90,0,0,19,0,0
+Nitriansky,Zlaté Moravce,Kostoľany pod Tribečom,240,2,0.0083,,,,,,,,,,,,
+Nitriansky,Zlaté Moravce,Ladice,538,1,0.0019,,,,,,,,,,,,
+Nitriansky,Zlaté Moravce,Lovce,498,6,0.012,,,,71,0,0,61,0,0,10,0,0
+Nitriansky,Zlaté Moravce,Machulince,701,5,0.0071,,,,,,,,,,,,
+Nitriansky,Zlaté Moravce,Malé Vozokany,185,0,0,,,,,,,,,,,,
+Nitriansky,Zlaté Moravce,Mankovce,425,5,0.0118,,,,48,0,0,29,0,0,19,0,0
+Nitriansky,Zlaté Moravce,Martin nad Žitavou,579,2,0.0035,,,,,,,,,,,,
+Nitriansky,Zlaté Moravce,Nemčiňany,462,2,0.0043,,,,,,,,,,,,
+Nitriansky,Zlaté Moravce,Neverice,740,5,0.0068,,,,,,,,,,,,
+Nitriansky,Zlaté Moravce,Nevidzany,510,7,0.0137,,,,131,0,0,120,0,0,11,0,0
+Nitriansky,Zlaté Moravce,Obyce,991,0,0,,,,,,,,,,,,
+Nitriansky,Zlaté Moravce,Skýcov,675,4,0.0059,,,,,,,,,,,,
+Nitriansky,Zlaté Moravce,Sľažany,639,3,0.0047,,,,,,,,,,,,
+Nitriansky,Zlaté Moravce,Slepčany,630,4,0.0063,,,,,,,,,,,,
+Nitriansky,Zlaté Moravce,Tekovské Nemce,636,9,0.0142,,,,151,5,0.0331,101,0,0,50,5,0.1
+Nitriansky,Zlaté Moravce,Tesárske Mlyňany,957,11,0.0115,,,,285,6,0.0211,162,0,0,123,6,0.0488
+Nitriansky,Zlaté Moravce,Topoľčianky,1473,5,0.0034,,,,,,,,,,,,
+Nitriansky,Zlaté Moravce,Velčice,620,1,0.0016,,,,,,,,,,,,
+Nitriansky,Zlaté Moravce,Veľké Vozokany,418,5,0.012,,,,73,0,0,52,0,0,21,0,0
+Nitriansky,Zlaté Moravce,Vieska,214,0,0,,,,,,,,,,,,
+Nitriansky,Zlaté Moravce,Volkovce,546,0,0,,,,,,,,,,,,
+Nitriansky,Zlaté Moravce,Zlaté Moravce,6468,34,0.0053,,,,,,,,,,,,
+Nitriansky,Zlaté Moravce,Žikava,431,3,0.007,,,,,,,,,,,,
+Nitriansky,Zlaté Moravce,Žitavany,1269,5,0.0039,,,,,,,,,,,,
+Prešovský,Bardejov,Abrahámovce,323,7,0.0217,278,3,0.0108,61,0,0,50,0,0,11,0,0
+Prešovský,Bardejov,Andrejová,344,7,0.0203,247,3,0.0121,63,0,0,43,0,0,20,0,0
+Prešovský,Bardejov,Bardejov,14398,220,0.0153,15718,112,0.0071,,,,,,,,,
+Prešovský,Bardejov,Bartošovce,503,20,0.0398,478,1,0.0021,,,,,,,,,
+Prešovský,Bardejov,Becherov,397,2,0.005,275,0,0,,,,,,,,,
+Prešovský,Bardejov,Beloveža,584,11,0.0188,538,5,0.0093,,,,,,,,,
+Prešovský,Bardejov,Bogliarka,71,0,0,86,0,0,,,,,,,,,
+Prešovský,Bardejov,Brezov,316,4,0.0127,268,2,0.0075,,,,,,,,,
+Prešovský,Bardejov,Brezovka,52,1,0.0192,56,0,0,,,,,,,,,
+Prešovský,Bardejov,Buclovany,106,5,0.0472,97,0,0,,,,,,,,,
+Prešovský,Bardejov,Cigeľka,303,1,0.0033,313,0,0,,,,,,,,,
+Prešovský,Bardejov,Dubinné,271,2,0.0074,268,1,0.0037,,,,,,,,,
+Prešovský,Bardejov,Frička,217,2,0.0092,204,0,0,,,,,,,,,
+Prešovský,Bardejov,Fričkovce,487,3,0.0062,472,4,0.0085,,,,,,,,,
+Prešovský,Bardejov,Gaboltov,204,1,0.0049,205,3,0.0146,126,0,0,113,0,0,13,0,0
+Prešovský,Bardejov,Gerlachov,636,13,0.0204,701,6,0.0086,,,,,,,,,
+Prešovský,Bardejov,Hankovce,310,7,0.0226,295,0,0,,,,,,,,,
+Prešovský,Bardejov,Harhaj,114,2,0.0175,141,1,0.0071,,,,,,,,,
+Prešovský,Bardejov,Hažlín,566,9,0.0159,591,1,0.0017,,,,,,,,,
+Prešovský,Bardejov,Hertník,664,8,0.012,652,11,0.0169,289,6,0.0208,228,6,0.0263,61,0,0
+Prešovský,Bardejov,Hervartov,252,3,0.0119,258,2,0.0078,,,,,,,,,
+Prešovský,Bardejov,Hrabovec,331,12,0.0363,306,6,0.0196,112,2,0.0179,89,1,0.0112,23,1,0.0435
+Prešovský,Bardejov,Hrabské,249,10,0.0402,306,10,0.0327,122,0,0,112,0,0,10,0,0
+Prešovský,Bardejov,Hutka,85,0,0,64,0,0,,,,,,,,,
+Prešovský,Bardejov,Chmeľová,276,0,0,343,0,0,,,,,,,,,
+Prešovský,Bardejov,Janovce,222,8,0.036,289,5,0.0173,88,5,0.0568,77,5,0.0649,11,0,0
+Prešovský,Bardejov,Jedlinka,126,4,0.0317,100,0,0,,,,,,,,,
+Prešovský,Bardejov,Kľušov,691,8,0.0116,692,3,0.0043,,,,,,,,,
+Prešovský,Bardejov,Kobyly,537,7,0.013,531,5,0.0094,,,,,,,,,
+Prešovský,Bardejov,Kochanovce,156,5,0.0321,132,1,0.0076,,,,,,,,,
+Prešovský,Bardejov,Komárov,211,1,0.0047,243,1,0.0041,,,,,,,,,
+Prešovský,Bardejov,Koprivnica,452,7,0.0155,433,5,0.0115,201,2,0.01,148,0,0,53,2,0.0377
+Prešovský,Bardejov,Kožany,120,6,0.05,101,0,0,,,,,,,,,
+Prešovský,Bardejov,Krivé,190,3,0.0158,164,1,0.0061,,,,,,,,,
+Prešovský,Bardejov,Kríže,80,1,0.0125,84,0,0,,,,,,,,,
+Prešovský,Bardejov,Kružlov,527,14,0.0266,551,3,0.0054,,,,,,,,,
+Prešovský,Bardejov,Kučín,139,1,0.0072,157,0,0,,,,,,,,,
+Prešovský,Bardejov,Kurima,634,15,0.0237,646,7,0.0108,194,1,0.0052,169,1,0.0059,25,0,0
+Prešovský,Bardejov,Kurov,468,1,0.0021,471,2,0.0042,,,,,,,,,
+Prešovský,Bardejov,Lascov,277,2,0.0072,233,1,0.0043,,,,,,,,,
+Prešovský,Bardejov,Lenartov,706,19,0.0269,679,7,0.0103,152,2,0.0132,137,2,0.0146,15,0,0
+Prešovský,Bardejov,Lipová,103,0,0,81,2,0.0247,19,0,0,17,0,0,2,0,0
+Prešovský,Bardejov,Livov,73,1,0.0137,73,1,0.0137,30,0,0,21,0,0,9,0,0
+Prešovský,Bardejov,Livovská Huta,71,1,0.0141,50,0,0,,,,,,,,,
+Prešovský,Bardejov,Lopúchov,185,2,0.0108,212,3,0.0142,46,2,0.0435,29,0,0,17,2,0.1176
+Prešovský,Bardejov,Lukavica,409,4,0.0098,361,3,0.0083,,,,,,,,,
+Prešovský,Bardejov,Lukov,505,6,0.0119,488,1,0.002,,,,,,,,,
+Prešovský,Bardejov,Malcov,753,46,0.0611,821,26,0.0317,316,3,0.0095,273,3,0.011,43,0,0
+Prešovský,Bardejov,Marhaň,603,2,0.0033,649,1,0.0015,,,,,,,,,
+Prešovský,Bardejov,Mikulášová,71,2,0.0282,73,0,0,,,,,,,,,
+Prešovský,Bardejov,Mokroluh,666,14,0.021,637,5,0.0078,,,,,,,,,
+Prešovský,Bardejov,Nemcovce,120,8,0.0667,113,0,0,,,,,,,,,
+Prešovský,Bardejov,Nižná Polianka,177,0,0,186,0,0,,,,,,,,,
+Prešovský,Bardejov,Nižná Voľa,178,1,0.0056,165,1,0.0061,,,,,,,,,
+Prešovský,Bardejov,Nižný Tvarožec,297,3,0.0101,286,0,0,,,,,,,,,
+Prešovský,Bardejov,Oľšavce,153,1,0.0065,148,0,0,,,,,,,,,
+Prešovský,Bardejov,Ondavka,175,0,0,,,,,,,,,,,,
+Prešovský,Bardejov,Ortuťová,110,6,0.0545,111,5,0.045,48,0,0,38,0,0,10,0,0
+Prešovský,Bardejov,Osikov,639,8,0.0125,651,5,0.0077,,,,,,,,,
+Prešovský,Bardejov,Petrová,575,8,0.0139,575,8,0.0139,170,1,0.0059,131,1,0.0076,39,0,0
+Prešovský,Bardejov,Poliakovce,131,3,0.0229,228,2,0.0088,,,,,,,,,
+Prešovský,Bardejov,Porúbka,244,2,0.0082,215,0,0,,,,,,,,,
+Prešovský,Bardejov,Raslavice,1479,14,0.0095,1462,5,0.0034,,,,,,,,,
+Prešovský,Bardejov,Regetovka,234,3,0.0128,155,0,0,,,,,,,,,
+Prešovský,Bardejov,Rešov,193,1,0.0052,212,0,0,,,,,,,,,
+Prešovský,Bardejov,Richvald,635,5,0.0079,629,5,0.0079,,,,,,,,,
+Prešovský,Bardejov,Rokytov,713,21,0.0295,267,11,0.0412,168,11,0.0655,90,2,0.0222,78,9,0.1154
+Prešovský,Bardejov,Smilno,470,18,0.0383,443,9,0.0203,172,2,0.0116,145,1,0.0069,27,1,0.037
+Prešovský,Bardejov,Snakov,460,4,0.0087,464,0,0,,,,,,,,,
+Prešovský,Bardejov,Stebnícka Huta,97,0,0,95,0,0,,,,,,,,,
+Prešovský,Bardejov,Stebník,303,1,0.0033,316,0,0,,,,,,,,,
+Prešovský,Bardejov,Stuľany,405,3,0.0074,416,4,0.0096,,,,,,,,,
+Prešovský,Bardejov,Sveržov,516,6,0.0116,501,3,0.006,,,,,,,,,
+Prešovský,Bardejov,Šarišské Čierne,140,3,0.0214,148,2,0.0135,37,1,0.027,30,0,0,7,1,0.1429
+Prešovský,Bardejov,Šašová,119,1,0.0084,114,0,0,,,,,,,,,
+Prešovský,Bardejov,Šiba,412,6,0.0146,380,2,0.0053,,,,,,,,,
+Prešovský,Bardejov,Tarnov,419,10,0.0239,343,5,0.0146,151,8,0.053,93,0,0,58,8,0.1379
+Prešovský,Bardejov,Tročany,290,3,0.0103,246,1,0.0041,,,,,,,,,
+Prešovský,Bardejov,Vaniškovce,247,4,0.0162,173,1,0.0058,,,,,,,,,
+Prešovský,Bardejov,Varadka,143,0,0,99,0,0,,,,,,,,,
+Prešovský,Bardejov,Vyšná Polianka,122,5,0.041,108,0,0,,,,,,,,,
+Prešovský,Bardejov,Vyšná Voľa,182,5,0.0275,211,3,0.0142,135,2,0.0148,119,2,0.0168,16,0,0
+Prešovský,Bardejov,Vyšný Kručov,129,0,0,155,2,0.0129,22,0,0,16,0,0,6,0,0
+Prešovský,Bardejov,Vyšný Tvarožec,76,0,0,82,0,0,,,,,,,,,
+Prešovský,Bardejov,Zborov,1496,32,0.0214,1646,32,0.0194,661,5,0.0076,547,2,0.0037,114,3,0.0263
+Prešovský,Bardejov,Zlaté,449,13,0.029,529,6,0.0113,197,1,0.0051,168,1,0.006,29,0,0
+Prešovský,Humenné,Baškovce,503,19,0.0378,436,6,0.0138,98,0,0,82,0,0,16,0,0
+Prešovský,Humenné,Brekov,723,18,0.0249,686,2,0.0029,,,,,,,,,
+Prešovský,Humenné,Brestov,382,12,0.0314,369,3,0.0081,,,,,,,,,
+Prešovský,Humenné,Hankovce,423,13,0.0307,383,4,0.0104,110,2,0.0182,96,2,0.0208,14,0,0
+Prešovský,Humenné,Hažín nad Cirochou,509,6,0.0118,566,4,0.0071,,,,,,,,,
+Prešovský,Humenné,Hrabovec nad Laborcom,333,11,0.033,321,2,0.0062,,,,,,,,,
+Prešovský,Humenné,Hrubov,287,9,0.0314,247,2,0.0081,,,,,,,,,
+Prešovský,Humenné,Hudcovce,377,3,0.008,270,2,0.0074,,,,,,,,,
+Prešovský,Humenné,Humenné,13599,220,0.0162,14657,77,0.0053,,,,,,,,,
+Prešovský,Humenné,Chlmec,513,5,0.0097,524,1,0.0019,,,,,,,,,
+Prešovský,Humenné,Jabloň,388,2,0.0052,289,0,0,,,,,,,,,
+Prešovský,Humenné,Jasenov,1009,20,0.0198,1032,12,0.0116,242,1,0.0041,165,0,0,77,1,0.013
+Prešovský,Humenné,Kamenica nad Cirochou,1306,30,0.023,1276,7,0.0055,,,,,,,,,
+Prešovský,Humenné,Kamienka,382,1,0.0026,369,0,0,,,,,,,,,
+Prešovský,Humenné,Karná,319,18,0.0564,298,0,0,,,,,,,,,
+Prešovský,Humenné,Kochanovce,622,9,0.0145,579,1,0.0017,,,,,,,,,
+Prešovský,Humenné,Košarovce,620,12,0.0194,627,7,0.0112,175,1,0.0057,149,1,0.0067,26,0,0
+Prešovský,Humenné,Koškovce,400,4,0.01,425,4,0.0094,,,,,,,,,
+Prešovský,Humenné,Lackovce,681,8,0.0117,635,3,0.0047,,,,,,,,,
+Prešovský,Humenné,Lieskovec,307,3,0.0098,309,0,0,,,,,,,,,
+Prešovský,Humenné,Ľubiša,761,19,0.025,714,11,0.0154,239,0,0,211,0,0,28,0,0
+Prešovský,Humenné,Lukačovce,493,15,0.0304,475,5,0.0105,129,1,0.0078,123,0,0,6,1,0.1667
+Prešovský,Humenné,Modra nad Cirochou,585,11,0.0188,555,2,0.0036,,,,,,,,,
+Prešovský,Humenné,Myslina,424,16,0.0377,369,4,0.0108,143,8,0.0559,114,1,0.0088,29,7,0.2414
+Prešovský,Humenné,Nižná Jablonka,193,2,0.0104,209,0,0,,,,,,,,,
+Prešovský,Humenné,Nižné Ladičkovce,375,8,0.0213,346,5,0.0145,87,0,0,79,0,0,8,0,0
+Prešovský,Humenné,Ohradzany,398,8,0.0201,400,8,0.02,117,8,0.0684,102,7,0.0686,15,1,0.0667
+Prešovský,Humenné,Pakostov,325,9,0.0277,330,1,0.003,,,,,,,,,
+Prešovský,Humenné,Papín,536,15,0.028,513,1,0.0019,,,,,,,,,
+Prešovský,Humenné,Ptičie,502,10,0.0199,357,4,0.0112,55,0,0,45,0,0,10,0,0
+Prešovský,Humenné,Rokytov pri Humennom,291,2,0.0069,301,0,0,,,,,,,,,
+Prešovský,Humenné,Rovné,332,4,0.012,304,1,0.0033,,,,,,,,,
+Prešovský,Humenné,Slovenská Volová,403,4,0.0099,383,2,0.0052,,,,,,,,,
+Prešovský,Humenné,Topoľovka,504,7,0.0139,486,0,0,,,,,,,,,
+Prešovský,Humenné,Udavské,683,8,0.0117,711,2,0.0028,,,,,,,,,
+Prešovský,Humenné,Vyšná Sitnica,452,5,0.0111,450,1,0.0022,,,,,,,,,
+Prešovský,Humenné,Vyšný Hrušov,313,10,0.0319,305,0,0,,,,,,,,,
+Prešovský,Humenné,Závadka,420,5,0.0119,386,2,0.0052,,,,,,,,,
+Prešovský,Humenné,Zbudské Dlhé,560,5,0.0089,484,9,0.0186,59,2,0.0339,49,2,0.0408,10,0,0
+Prešovský,Humenné,Zubné,399,12,0.0301,374,2,0.0053,,,,,,,,,
+Prešovský,Kežmarok,Abrahámovce,100,2,0.02,255,0,0,,,,,,,,,
+Prešovský,Kežmarok,Bušovce,420,4,0.0095,408,2,0.0049,,,,,,,,,
+Prešovský,Kežmarok,Červený Kláštor,90,3,0.0333,122,0,0,,,,,,,,,
+Prešovský,Kežmarok,Havka,0,0,0,,,,,,,,,,,,
+Prešovský,Kežmarok,Holumnica,560,3,0.0054,508,1,0.002,,,,,,,,,
+Prešovský,Kežmarok,Hradisko,399,13,0.0326,215,0,0,,,,,,,,,
+Prešovský,Kežmarok,Huncovce,1849,30,0.0162,1723,11,0.0064,,,,,,,,,
+Prešovský,Kežmarok,Ihľany,961,6,0.0062,985,6,0.0061,,,,,,,,,
+Prešovský,Kežmarok,Jezersko,186,7,0.0376,150,2,0.0133,37,2,0.0541,21,2,0.0952,16,0,0
+Prešovský,Kežmarok,Jurské,900,12,0.0133,808,11,0.0136,251,2,0.008,233,2,0.0086,18,0,0
+Prešovský,Kežmarok,Kežmarok,8193,154,0.0188,8823,61,0.0069,,,,,,,,,
+Prešovský,Kežmarok,Krížová Ves,1467,39,0.0266,1304,15,0.0115,377,6,0.0159,308,1,0.0032,69,5,0.0725
+Prešovský,Kežmarok,Lechnica,223,2,0.009,221,0,0,,,,,,,,,
+Prešovský,Kežmarok,Lendak,3095,89,0.0288,2994,48,0.016,1730,49,0.0283,1678,48,0.0286,52,1,0.0192
+Prešovský,Kežmarok,Ľubica,2707,38,0.014,2556,24,0.0094,,,,,,,,,
+Prešovský,Kežmarok,Majere,53,2,0.0377,57,0,0,,,,,,,,,
+Prešovský,Kežmarok,Malá Franková,333,10,0.03,116,2,0.0172,45,1,0.0222,27,0,0,18,1,0.0556
+Prešovský,Kežmarok,Malý Slavkov,780,12,0.0154,760,1,0.0013,,,,,,,,,
+Prešovský,Kežmarok,Matiašovce,432,28,0.0648,409,3,0.0073,,,,,,,,,
+Prešovský,Kežmarok,Mlynčeky,533,7,0.0131,543,2,0.0037,,,,,,,,,
+Prešovský,Kežmarok,Osturňa,285,5,0.0175,292,1,0.0034,,,,,,,,,
+Prešovský,Kežmarok,Podhorany,1456,17,0.0117,1859,18,0.0097,60,1,0.0167,53,1,0.0189,7,0,0
+Prešovský,Kežmarok,Rakúsy,1935,23,0.0119,1872,15,0.008,,,,,,,,,
+Prešovský,Kežmarok,Reľov,291,9,0.0309,264,4,0.0152,85,2,0.0235,84,2,0.0238,1,0,0
+Prešovský,Kežmarok,Slovenská Ves,1275,15,0.0118,1173,16,0.0136,461,22,0.0477,404,17,0.0421,57,5,0.0877
+Prešovský,Kežmarok,Spišská Belá,3708,76,0.0205,3860,27,0.007,,,,,,,,,
+Prešovský,Kežmarok,Spišská Stará Ves,1187,25,0.0211,1273,17,0.0134,571,7,0.0123,512,6,0.0117,59,1,0.0169
+Prešovský,Kežmarok,Spišské Hanušovce,457,32,0.07,378,9,0.0238,193,2,0.0104,193,2,0.0104,0,0,0
+Prešovský,Kežmarok,Stará Lesná,672,8,0.0119,683,5,0.0073,,,,,,,,,
+Prešovský,Kežmarok,Stráne pod Tatrami,1077,16,0.0149,998,6,0.006,,,,,,,,,
+Prešovský,Kežmarok,Toporec,837,5,0.006,822,10,0.0122,304,3,0.0099,260,3,0.0115,44,0,0
+Prešovský,Kežmarok,Tvarožná,574,10,0.0174,526,3,0.0057,,,,,,,,,
+Prešovský,Kežmarok,Veľká Franková,270,13,0.0481,283,4,0.0141,120,1,0.0083,96,1,0.0104,24,0,0
+Prešovský,Kežmarok,Veľká Lomnica,3115,65,0.0209,3163,26,0.0082,,,,,,,,,
+Prešovský,Kežmarok,Vlková,659,14,0.0212,640,7,0.0109,301,13,0.0432,238,5,0.021,63,8,0.127
+Prešovský,Kežmarok,Vlkovce,342,7,0.0205,323,1,0.0031,,,,,,,,,
+Prešovský,Kežmarok,Vojňany,190,3,0.0158,183,4,0.0219,96,1,0.0104,84,1,0.0119,12,0,0
+Prešovský,Kežmarok,Vrbov,840,9,0.0107,799,11,0.0138,361,8,0.0222,256,4,0.0156,105,4,0.0381
+Prešovský,Kežmarok,Výborná,893,17,0.019,813,6,0.0074,,,,,,,,,
+Prešovský,Kežmarok,Zálesie,51,1,0.0196,75,4,0.0533,26,2,0.0769,15,0,0,11,2,0.1818
+Prešovský,Kežmarok,Žakovce,564,14,0.0248,532,7,0.0132,251,12,0.0478,161,4,0.0248,90,8,0.0889
+Prešovský,Levoča,Baldovce,247,3,0.0121,215,2,0.0093,,,,,,,,,
+Prešovský,Levoča,Beharovce,114,2,0.0175,212,0,0,,,,,,,,,
+Prešovský,Levoča,Bijacovce,578,16,0.0277,575,1,0.0017,,,,,,,,,
+Prešovský,Levoča,Brutovce,82,0,0,92,0,0,,,,,,,,,
+Prešovský,Levoča,Buglovce,146,1,0.0068,140,1,0.0071,,,,,,,,,
+Prešovský,Levoča,Dlhé Stráže,416,5,0.012,376,1,0.0027,,,,,,,,,
+Prešovský,Levoča,Doľany,327,4,0.0122,342,1,0.0029,,,,,,,,,
+Prešovský,Levoča,Domaňovce,622,14,0.0225,595,8,0.0134,256,13,0.0508,192,4,0.0208,64,9,0.1406
+Prešovský,Levoča,Dravce,558,23,0.0412,504,7,0.0139,175,10,0.0571,138,7,0.0507,37,3,0.0811
+Prešovský,Levoča,Dúbrava,223,2,0.009,218,0,0,,,,,,,,,
+Prešovský,Levoča,Granč - Petrovce,509,9,0.0177,452,5,0.0111,126,1,0.0079,104,0,0,22,1,0.0455
+Prešovský,Levoča,Harakovce,165,3,0.0182,,,,,,,,,,,,
+Prešovský,Levoča,Jablonov,538,5,0.0093,545,3,0.0055,,,,,,,,,
+Prešovský,Levoča,Klčov,586,9,0.0154,462,9,0.0195,124,2,0.0161,96,2,0.0208,28,0,0
+Prešovský,Levoča,Korytné,142,6,0.0423,142,1,0.007,,,,,,,,,
+Prešovský,Levoča,Kurimany,212,7,0.033,197,4,0.0203,122,1,0.0082,102,1,0.0098,20,0,0
+Prešovský,Levoča,Levoča,6243,116,0.0186,6356,83,0.0131,2213,36,0.0163,2088,34,0.0163,125,2,0.016
+Prešovský,Levoča,Lúčka,47,0,0,43,1,0.0233,22,0,0,10,0,0,12,0,0
+Prešovský,Levoča,Nemešany,451,8,0.0177,352,3,0.0085,,,,,,,,,
+Prešovský,Levoča,Nižné Repaše,176,3,0.017,154,0,0,,,,,,,,,
+Prešovský,Levoča,Oľšavica,128,0,0,133,0,0,,,,,,,,,
+Prešovský,Levoča,Ordzovany,223,1,0.0045,231,2,0.0087,,,,,,,,,
+Prešovský,Levoča,Pavľany,208,2,0.0096,154,0,0,,,,,,,,,
+Prešovský,Levoča,Poľanovce,158,5,0.0316,152,2,0.0132,38,1,0.0263,12,0,0,26,1,0.0385
+Prešovský,Levoča,Pongrácovce,145,0,0,,,,,,,,,,,,
+Prešovský,Levoča,Spišské Podhradie,1864,25,0.0134,1962,9,0.0046,,,,,,,,,
+Prešovský,Levoča,Spišský Hrhov,812,35,0.0431,817,10,0.0122,278,6,0.0216,247,6,0.0243,31,0,0
+Prešovský,Levoča,Spišský Štvrtok,1621,52,0.0321,1519,14,0.0092,,,,,,,,,
+Prešovský,Levoča,Studenec,186,3,0.0161,188,0,0,,,,,,,,,
+Prešovský,Levoča,Torysky,162,1,0.0062,152,0,0,,,,,,,,,
+Prešovský,Levoča,Úloža,127,2,0.0157,145,3,0.0207,49,0,0,37,0,0,12,0,0
+Prešovský,Levoča,Vyšné Repaše,124,0,0,125,2,0.016,26,0,0,18,0,0,8,0,0
+Prešovský,Levoča,Vyšný Slavkov,204,11,0.0539,197,0,0,,,,,,,,,
+Prešovský,Medzilaborce,Čabalovce,172,2,0.0116,185,1,0.0054,,,,,,,,,
+Prešovský,Medzilaborce,Čabiny,382,4,0.0105,350,1,0.0029,,,,,,,,,
+Prešovský,Medzilaborce,Habura,482,3,0.0062,564,2,0.0035,,,,,,,,,
+Prešovský,Medzilaborce,Kalinov,334,10,0.0299,210,1,0.0048,,,,,,,,,
+Prešovský,Medzilaborce,Krásny Brod,362,4,0.011,425,1,0.0024,,,,,,,,,
+Prešovský,Medzilaborce,Medzilaborce,3185,32,0.01,2663,7,0.0026,,,,,,,,,
+Prešovský,Medzilaborce,Ňagov,237,1,0.0042,241,1,0.0041,,,,,,,,,
+Prešovský,Medzilaborce,Oľka,119,0,0,192,0,0,,,,,,,,,
+Prešovský,Medzilaborce,Palota,191,2,0.0105,194,0,0,,,,,,,,,
+Prešovský,Medzilaborce,Radvaň nad Laborcom,527,27,0.0512,401,0,0,,,,,,,,,
+Prešovský,Medzilaborce,Volica,201,1,0.005,207,0,0,,,,,,,,,
+Prešovský,Medzilaborce,Výrava,366,3,0.0082,361,3,0.0083,,,,,,,,,
+Prešovský,Medzilaborce,Zbudská Belá,422,2,0.0047,149,0,0,,,,,,,,,
+Prešovský,Poprad,Batizovce,1464,32,0.0219,1298,2,0.0015,,,,,,,,,
+Prešovský,Poprad,Gánovce,914,7,0.0077,891,3,0.0034,,,,,,,,,
+Prešovský,Poprad,Gerlachov,535,7,0.0131,487,1,0.0021,,,,,,,,,
+Prešovský,Poprad,Hozelec,600,20,0.0333,531,3,0.0056,,,,,,,,,
+Prešovský,Poprad,Hôrka,1324,26,0.0196,1290,7,0.0054,,,,,,,,,
+Prešovský,Poprad,Hranovnica,2024,36,0.0178,1886,15,0.008,,,,,,,,,
+Prešovský,Poprad,Jánovce,1124,61,0.0543,977,10,0.0102,605,10,0.0165,449,5,0.0111,156,5,0.0321
+Prešovský,Poprad,Kravany,604,3,0.005,573,1,0.0017,,,,,,,,,
+Prešovský,Poprad,Liptovská Teplička,1594,28,0.0176,1516,8,0.0053,,,,,,,,,
+Prešovský,Poprad,Lučivná,807,9,0.0112,630,2,0.0032,,,,,,,,,
+Prešovský,Poprad,Mengusovce,537,3,0.0056,471,1,0.0021,,,,,,,,,
+Prešovský,Poprad,Mlynica,547,11,0.0201,457,2,0.0044,,,,,,,,,
+Prešovský,Poprad,Nová Lesná,1068,9,0.0084,1090,3,0.0028,,,,,,,,,
+Prešovský,Poprad,Poprad,24910,343,0.0138,25615,162,0.0063,,,,,,,,,
+Prešovský,Poprad,Spišská Teplica,1539,34,0.0221,1379,10,0.0073,,,,,,,,,
+Prešovský,Poprad,Spišské Bystré,1715,28,0.0163,1609,11,0.0068,,,,,,,,,
+Prešovský,Poprad,Spišský Štiavnik,1741,111,0.0638,1460,30,0.0205,464,9,0.0194,383,1,0.0026,81,8,0.0988
+Prešovský,Poprad,Svit,3951,68,0.0172,3591,18,0.005,,,,,,,,,
+Prešovský,Poprad,Štôla,464,9,0.0194,418,1,0.0024,,,,,,,,,
+Prešovský,Poprad,Štrba,2552,26,0.0102,2723,15,0.0055,,,,,,,,,
+Prešovský,Poprad,Šuňava,1090,10,0.0092,1083,6,0.0055,,,,,,,,,
+Prešovský,Poprad,Švábovce,923,6,0.0065,937,6,0.0064,,,,,,,,,
+Prešovský,Poprad,Tatranská Javorina,331,3,0.0091,274,3,0.0109,55,0,0,32,0,0,23,0,0
+Prešovský,Poprad,Veľký Slavkov,765,14,0.0183,779,6,0.0077,,,,,,,,,
+Prešovský,Poprad,Vernár,502,6,0.012,475,2,0.0042,,,,,,,,,
+Prešovský,Poprad,Vikartovce,1222,39,0.0319,1091,8,0.0073,,,,,,,,,
+Prešovský,Poprad,Vydrník,820,55,0.0671,686,14,0.0204,131,1,0.0076,122,1,0.0082,9,0,0
+Prešovský,Poprad,Vysoké Tatry,2678,32,0.0119,3092,13,0.0042,,,,,,,,,
+Prešovský,Poprad,Ždiar,727,23,0.0316,789,1,0.0013,,,,,,,,,
+Prešovský,Prešov,Abranovce,708,7,0.0099,561,3,0.0053,,,,,,,,,
+Prešovský,Prešov,Bajerov,423,10,0.0236,349,0,0,,,,,,,,,
+Prešovský,Prešov,Bertotovce,166,4,0.0241,340,3,0.0088,,,,,,,,,
+Prešovský,Prešov,Brestov,278,5,0.018,306,0,0,,,,,,,,,
+Prešovský,Prešov,Bretejovce,371,5,0.0135,1261,6,0.0048,,,,,,,,,
+Prešovský,Prešov,Brežany,214,5,0.0234,168,1,0.006,,,,,,,,,
+Prešovský,Prešov,Bzenov,578,10,0.0173,567,0,0,,,,,,,,,
+Prešovský,Prešov,Čelovce,211,3,0.0142,203,1,0.0049,,,,,,,,,
+Prešovský,Prešov,Červenica,686,2,0.0029,718,4,0.0056,,,,,,,,,
+Prešovský,Prešov,Demjata,648,3,0.0046,719,4,0.0056,,,,,,,,,
+Prešovský,Prešov,Drienov,1365,12,0.0088,2299,13,0.0057,,,,,,,,,
+Prešovský,Prešov,Drienovská Nová Ves,628,11,0.0175,947,5,0.0053,,,,,,,,,
+Prešovský,Prešov,Dulova Ves,1073,9,0.0084,1046,6,0.0057,,,,,,,,,
+Prešovský,Prešov,Fintice,1279,11,0.0086,1441,7,0.0049,,,,,,,,,
+Prešovský,Prešov,Fričovce,607,16,0.0264,655,3,0.0046,,,,,,,,,
+Prešovský,Prešov,Fulianka,470,6,0.0128,303,4,0.0132,130,3,0.0231,83,1,0.012,47,2,0.0426
+Prešovský,Prešov,Geraltov,99,5,0.0505,185,2,0.0108,56,1,0.0179,27,1,0.037,29,0,0
+Prešovský,Prešov,Gregorovce,642,2,0.0031,626,6,0.0096,,,,,,,,,
+Prešovský,Prešov,Haniska,710,4,0.0056,680,1,0.0015,,,,,,,,,
+Prešovský,Prešov,Hendrichovce,223,5,0.0224,213,1,0.0047,,,,,,,,,
+Prešovský,Prešov,Hermanovce,876,9,0.0103,840,3,0.0036,,,,,,,,,
+Prešovský,Prešov,Hrabkov,510,1,0.002,494,1,0.002,,,,,,,,,
+Prešovský,Prešov,Chmeľov,598,6,0.01,594,2,0.0034,,,,,,,,,
+Prešovský,Prešov,Chmeľovec,360,7,0.0194,341,2,0.0059,,,,,,,,,
+Prešovský,Prešov,Chmiňany,840,5,0.006,762,2,0.0026,,,,,,,,,
+Prešovský,Prešov,Chminianska Nová Ves,721,6,0.0083,746,2,0.0027,,,,,,,,,
+Prešovský,Prešov,Chminianske Jakubovany,1042,0,0,1027,7,0.0068,,,,,,,,,
+Prešovský,Prešov,Janov,194,1,0.0052,193,0,0,,,,,,,,,
+Prešovský,Prešov,Janovík,380,3,0.0079,1138,6,0.0053,,,,,,,,,
+Prešovský,Prešov,Kapušany,1495,24,0.0161,1466,2,0.0014,,,,,,,,,
+Prešovský,Prešov,Kendice,1160,6,0.0052,1546,11,0.0071,,,,,,,,,
+Prešovský,Prešov,Klenov,278,7,0.0252,228,1,0.0044,,,,,,,,,
+Prešovský,Prešov,Kojatice,828,23,0.0278,717,4,0.0056,,,,,,,,,
+Prešovský,Prešov,Kokošovce,478,12,0.0251,658,3,0.0046,,,,,,,,,
+Prešovský,Prešov,Krížovany,217,1,0.0046,175,0,0,,,,,,,,,
+Prešovský,Prešov,Kvačany,151,1,0.0066,227,0,0,,,,,,,,,
+Prešovský,Prešov,Lada,600,6,0.01,550,6,0.0109,409,21,0.0513,176,3,0.017,233,18,0.0773
+Prešovský,Prešov,Lažany,517,11,0.0213,117,0,0,,,,,,,,,
+Prešovský,Prešov,Lemešany,1297,16,0.0123,2356,12,0.0051,,,,,,,,,
+Prešovský,Prešov,Lesíček,250,1,0.004,254,1,0.0039,,,,,,,,,
+Prešovský,Prešov,Ličartovce,677,6,0.0089,1150,3,0.0026,,,,,,,,,
+Prešovský,Prešov,Lipníky,406,3,0.0074,428,1,0.0023,,,,,,,,,
+Prešovský,Prešov,Lipovce,257,3,0.0117,293,0,0,,,,,,,,,
+Prešovský,Prešov,Ľubotice,2067,28,0.0135,2189,9,0.0041,,,,,,,,,
+Prešovský,Prešov,Ľubovec,428,0,0,391,3,0.0077,,,,,,,,,
+Prešovský,Prešov,Lúčina,136,1,0.0074,127,0,0,,,,,,,,,
+Prešovský,Prešov,Malý Slivník,704,18,0.0256,577,21,0.0364,387,7,0.0181,360,6,0.0167,27,1,0.037
+Prešovský,Prešov,Malý Šariš,1230,20,0.0163,1200,2,0.0017,,,,,,,,,
+Prešovský,Prešov,Medzany,693,6,0.0087,751,4,0.0053,,,,,,,,,
+Prešovský,Prešov,Miklušovce,166,1,0.006,183,1,0.0055,,,,,,,,,
+Prešovský,Prešov,Mirkovce,645,5,0.0078,714,0,0,,,,,,,,,
+Prešovský,Prešov,Mošurov,106,0,0,169,0,0,,,,,,,,,
+Prešovský,Prešov,Nemcovce,298,0,0,281,0,0,,,,,,,,,
+Prešovský,Prešov,Okružná,381,6,0.0157,365,3,0.0082,,,,,,,,,
+Prešovský,Prešov,Ondrašovce,147,0,0,231,0,0,,,,,,,,,
+Prešovský,Prešov,Ovčie,538,3,0.0056,494,0,0,,,,,,,,,
+Prešovský,Prešov,Petrovany,1140,8,0.007,1171,5,0.0043,,,,,,,,,
+Prešovský,Prešov,Podhorany,543,15,0.0276,714,11,0.0154,,,,,,,,,
+Prešovský,Prešov,Podhradík,229,2,0.0087,234,0,0,,,,,,,,,
+Prešovský,Prešov,Prešov,41406,418,0.0101,44309,188,0.0042,,,,,,,,,
+Prešovský,Prešov,Proč,231,0,0,239,1,0.0042,,,,,,,,,
+Prešovský,Prešov,Pušovce,381,4,0.0105,350,1,0.0029,,,,,,,,,
+Prešovský,Prešov,Radatice,563,3,0.0053,531,1,0.0019,,,,,,,,,
+Prešovský,Prešov,Rokycany,531,3,0.0056,519,0,0,,,,,,,,,
+Prešovský,Prešov,Ruská Nová Ves,985,5,0.0051,936,3,0.0032,,,,,,,,,
+Prešovský,Prešov,Sedlice,648,8,0.0123,640,3,0.0047,,,,,,,,,
+Prešovský,Prešov,Seniakovce,134,0,0,559,5,0.0089,,,,,,,,,
+Prešovský,Prešov,Suchá Dolina,112,1,0.0089,113,0,0,,,,,,,,,
+Prešovský,Prešov,Svinia,1175,4,0.0034,1332,0,0,,,,,,,,,
+Prešovský,Prešov,Šarišská Poruba,436,5,0.0115,414,0,0,,,,,,,,,
+Prešovský,Prešov,Šarišská Trstená,209,0,0,221,0,0,,,,,,,,,
+Prešovský,Prešov,Šarišské Bohdanovce,645,5,0.0078,1584,4,0.0025,,,,,,,,,
+Prešovský,Prešov,Šindliar,578,1,0.0017,523,1,0.0019,,,,,,,,,
+Prešovský,Prešov,Široké,1332,16,0.012,1399,7,0.005,,,,,,,,,
+Prešovský,Prešov,Štefanovce,299,0,0,221,0,0,,,,,,,,,
+Prešovský,Prešov,Teriakovce,889,5,0.0056,759,3,0.004,,,,,,,,,
+Prešovský,Prešov,Terňa,890,12,0.0135,895,4,0.0045,,,,,,,,,
+Prešovský,Prešov,Trnkov,128,4,0.0313,133,0,0,,,,,,,,,
+Prešovský,Prešov,Tuhrina,332,2,0.006,377,0,0,,,,,,,,,
+Prešovský,Prešov,Tulčík,793,13,0.0164,774,3,0.0039,,,,,,,,,
+Prešovský,Prešov,Varhaňovce,1001,3,0.003,1171,6,0.0051,,,,,,,,,
+Prešovský,Prešov,Veľký Slivník,188,3,0.016,175,2,0.0114,80,2,0.025,65,0,0,15,2,0.1333
+Prešovský,Prešov,Veľký Šariš,4242,35,0.0083,4256,13,0.0031,,,,,,,,,
+Prešovský,Prešov,Víťaz,1273,16,0.0126,1284,6,0.0047,,,,,,,,,
+Prešovský,Prešov,Vyšná Šebastová,1066,10,0.0094,963,2,0.0021,,,,,,,,,
+Prešovský,Prešov,Záborské,668,7,0.0105,737,7,0.0095,,,,,,,,,
+Prešovský,Prešov,Záhradné,1052,10,0.0095,856,3,0.0035,,,,,,,,,
+Prešovský,Prešov,Zlatá Baňa,320,6,0.0188,323,2,0.0062,,,,,,,,,
+Prešovský,Prešov,Žehňa,798,15,0.0188,731,6,0.0082,,,,,,,,,
+Prešovský,Prešov,Žipov,258,2,0.0078,256,9,0.0352,124,3,0.0242,77,2,0.026,47,1,0.0213
+Prešovský,Prešov,Župčany,1273,9,0.0071,1211,5,0.0041,,,,,,,,,
+Prešovský,Sabinov,Bajerovce,189,6,0.0317,198,3,0.0152,48,1,0.0208,43,1,0.0233,5,0,0
+Prešovský,Sabinov,Bodovce,179,4,0.0223,169,1,0.0059,,,,,,,,,
+Prešovský,Sabinov,Brezovica,1196,18,0.0151,1068,5,0.0047,,,,,,,,,
+Prešovský,Sabinov,Brezovička,143,2,0.014,155,0,0,,,,,,,,,
+Prešovský,Sabinov,Červená Voda,398,8,0.0201,324,6,0.0185,65,0,0,58,0,0,7,0,0
+Prešovský,Sabinov,Červenica pri Sabinove,582,8,0.0137,579,1,0.0017,,,,,,,,,
+Prešovský,Sabinov,Ďačov,496,24,0.0484,476,7,0.0147,192,4,0.0208,146,2,0.0137,46,2,0.0435
+Prešovský,Sabinov,Daletice,386,6,0.0155,71,0,0,,,,,,,,,
+Prešovský,Sabinov,Drienica,635,16,0.0252,665,5,0.0075,,,,,,,,,
+Prešovský,Sabinov,Dubovica,754,15,0.0199,765,3,0.0039,,,,,,,,,
+Prešovský,Sabinov,Hanigovce,256,5,0.0195,175,3,0.0171,30,0,0,23,0,0,7,0,0
+Prešovský,Sabinov,Hubošovce,275,5,0.0182,267,1,0.0037,,,,,,,,,
+Prešovský,Sabinov,Jakovany,342,8,0.0234,300,2,0.0067,,,,,,,,,
+Prešovský,Sabinov,Jakubova Voľa,257,6,0.0233,242,4,0.0165,92,0,0,80,0,0,12,0,0
+Prešovský,Sabinov,Jakubovany,627,14,0.0223,612,10,0.0163,215,1,0.0047,198,1,0.0051,17,0,0
+Prešovský,Sabinov,Jarovnice,4004,62,0.0155,3761,51,0.0136,1737,52,0.0299,1663,48,0.0289,74,4,0.0541
+Prešovský,Sabinov,Kamenica,979,33,0.0337,986,11,0.0112,129,0,0,110,0,0,19,0,0
+Prešovský,Sabinov,Krásna Lúka,480,21,0.0438,424,2,0.0047,,,,,,,,,
+Prešovský,Sabinov,Krivany,669,16,0.0239,623,1,0.0016,,,,,,,,,
+Prešovský,Sabinov,Lipany,3096,62,0.02,3256,32,0.0098,,,,,,,,,
+Prešovský,Sabinov,Lúčka,566,17,0.03,510,4,0.0078,,,,,,,,,
+Prešovský,Sabinov,Ľutina,296,6,0.0203,304,0,0,,,,,,,,,
+Prešovský,Sabinov,Milpoš,433,4,0.0092,444,1,0.0023,,,,,,,,,
+Prešovský,Sabinov,Nižný Slavkov,446,12,0.0269,427,5,0.0117,114,0,0,95,0,0,19,0,0
+Prešovský,Sabinov,Olejníkov,418,9,0.0215,377,1,0.0027,,,,,,,,,
+Prešovský,Sabinov,Oľšov,216,7,0.0324,210,0,0,,,,,,,,,
+Prešovský,Sabinov,Ostrovany,1157,5,0.0043,1083,6,0.0055,,,,,,,,,
+Prešovský,Sabinov,Pečovská Nová Ves,1682,18,0.0107,1688,8,0.0047,,,,,,,,,
+Prešovský,Sabinov,Poloma,491,20,0.0407,485,1,0.0021,,,,,,,,,
+Prešovský,Sabinov,Ratvaj,97,2,0.0206,81,1,0.0123,41,0,0,25,0,0,16,0,0
+Prešovský,Sabinov,Ražňany,1120,21,0.0188,966,10,0.0104,230,2,0.0087,204,0,0,26,2,0.0769
+Prešovský,Sabinov,Renčišov,320,4,0.0125,262,3,0.0115,53,0,0,35,0,0,18,0,0
+Prešovský,Sabinov,Rožkovany,821,20,0.0244,789,2,0.0025,,,,,,,,,
+Prešovský,Sabinov,Sabinov,5770,194,0.0336,6138,75,0.0122,1695,23,0.0136,1384,4,0.0029,311,19,0.0611
+Prešovský,Sabinov,Šarišské Dravce,629,25,0.0397,611,2,0.0033,,,,,,,,,
+Prešovský,Sabinov,Šarišské Michaľany,1837,27,0.0147,1811,8,0.0044,,,,,,,,,
+Prešovský,Sabinov,Šarišské Sokolovce,429,16,0.0373,394,5,0.0127,73,1,0.0137,47,0,0,26,1,0.0385
+Prešovský,Sabinov,Tichý Potok,159,1,0.0063,179,0,0,,,,,,,,,
+Prešovský,Sabinov,Torysa,940,29,0.0309,1420,7,0.0049,,,,,,,,,
+Prešovský,Sabinov,Uzovce,432,8,0.0185,405,2,0.0049,,,,,,,,,
+Prešovský,Sabinov,Uzovské Pekľany,333,6,0.018,305,0,0,,,,,,,,,
+Prešovský,Sabinov,Uzovský Šalgov,580,7,0.0121,525,6,0.0114,179,1,0.0056,144,1,0.0069,35,0,0
+Prešovský,Sabinov,Vysoká,251,7,0.0279,227,0,0,,,,,,,,,
+Prešovský,Snina,Belá nad Cirochou,2102,27,0.0128,2044,8,0.0039,,,,,,,,,
+Prešovský,Snina,Čukalovce,322,4,0.0124,300,3,0.01,51,0,0,24,0,0,27,0,0
+Prešovský,Snina,Dlhé nad Cirochou,1025,24,0.0234,998,6,0.006,,,,,,,,,
+Prešovský,Snina,Dúbrava,278,2,0.0072,273,5,0.0183,43,0,0,24,0,0,19,0,0
+Prešovský,Snina,Hostovice,392,9,0.023,307,0,0,,,,,,,,,
+Prešovský,Snina,Kalná Roztoka,338,7,0.0207,356,0,0,,,,,,,,,
+Prešovský,Snina,Klenová,456,7,0.0154,374,0,0,,,,,,,,,
+Prešovský,Snina,Kolonica,427,4,0.0094,451,2,0.0044,,,,,,,,,
+Prešovský,Snina,Ladomirov,260,3,0.0115,220,0,0,,,,,,,,,
+Prešovský,Snina,Pčoliné,412,7,0.017,423,3,0.0071,,,,,,,,,
+Prešovský,Snina,Pichne,517,7,0.0135,462,3,0.0065,,,,,,,,,
+Prešovský,Snina,Ruský Potok,221,5,0.0226,174,0,0,,,,,,,,,
+Prešovský,Snina,Snina,8115,182,0.0224,8575,55,0.0064,,,,,,,,,
+Prešovský,Snina,Stakčín,1091,15,0.0137,1138,5,0.0044,,,,,,,,,
+Prešovský,Snina,Stakčínska Roztoka,404,8,0.0198,284,4,0.0141,52,0,0,37,0,0,15,0,0
+Prešovský,Snina,Šmigovec,184,3,0.0163,418,0,0,,,,,,,,,
+Prešovský,Snina,Topoľa,406,1,0.0025,334,1,0.003,,,,,,,,,
+Prešovský,Snina,Ubľa,438,8,0.0183,446,3,0.0067,,,,,,,,,
+Prešovský,Snina,Ulič,628,10,0.0159,605,1,0.0017,,,,,,,,,
+Prešovský,Snina,Zboj,472,6,0.0127,447,0,0,,,,,,,,,
+Prešovský,Snina,Zemplínske Hámre,634,6,0.0095,767,12,0.0156,169,2,0.0118,146,2,0.0137,23,0,0
+Prešovský,Stará Ľubovňa,Čirč,713,81,0.1136,535,32,0.0598,167,3,0.018,151,3,0.0199,16,0,0
+Prešovský,Stará Ľubovňa,Ďurková,60,1,0.0167,89,0,0,,,,,,,,,
+Prešovský,Stará Ľubovňa,Forbasy,474,20,0.0422,340,6,0.0176,213,2,0.0094,173,1,0.0058,40,1,0.025
+Prešovský,Stará Ľubovňa,Hajtovka,28,0,0,35,0,0,,,,,,,,,
+Prešovský,Stará Ľubovňa,Haligovce,411,15,0.0365,416,8,0.0192,192,4,0.0208,152,4,0.0263,40,0,0
+Prešovský,Stará Ľubovňa,Hniezdne,646,12,0.0186,660,2,0.003,,,,,,,,,
+Prešovský,Stará Ľubovňa,Hraničné,178,2,0.0112,157,3,0.0191,58,3,0.0517,44,2,0.0455,14,1,0.0714
+Prešovský,Stará Ľubovňa,Hromoš,406,20,0.0493,314,5,0.0159,98,2,0.0204,74,0,0,24,2,0.0833
+Prešovský,Stará Ľubovňa,Chmeľnica,558,9,0.0161,589,2,0.0034,,,,,,,,,
+Prešovský,Stará Ľubovňa,Jakubany,1293,29,0.0224,1218,21,0.0172,316,12,0.038,294,11,0.0374,22,1,0.0455
+Prešovský,Stará Ľubovňa,Jarabina,441,17,0.0385,412,2,0.0049,,,,,,,,,
+Prešovský,Stará Ľubovňa,Kamienka,683,26,0.0381,667,19,0.0285,194,8,0.0412,178,8,0.0449,16,0,0
+Prešovský,Stará Ľubovňa,Kolačkov,732,38,0.0519,645,14,0.0217,394,10,0.0254,384,10,0.026,10,0,0
+Prešovský,Stará Ľubovňa,Kremná,0,0,0,91,2,0.022,40,1,0.025,32,0,0,8,1,0.125
+Prešovský,Stará Ľubovňa,Kyjov,794,42,0.0529,468,4,0.0085,,,,,,,,,
+Prešovský,Stará Ľubovňa,Lacková,144,0,0,154,4,0.026,43,2,0.0465,34,2,0.0588,9,0,0
+Prešovský,Stará Ľubovňa,Legnava,138,1,0.0072,107,1,0.0093,,,,,,,,,
+Prešovský,Stará Ľubovňa,Lesnica,339,16,0.0472,261,2,0.0077,,,,,,,,,
+Prešovský,Stará Ľubovňa,Litmanová,319,4,0.0125,305,2,0.0066,,,,,,,,,
+Prešovský,Stará Ľubovňa,Lomnička,1581,17,0.0108,1640,10,0.0061,,,,,,,,,
+Prešovský,Stará Ľubovňa,Ľubotín,480,7,0.0146,644,12,0.0186,271,7,0.0258,216,5,0.0231,55,2,0.0364
+Prešovský,Stará Ľubovňa,Malý Lipník,253,4,0.0158,230,5,0.0217,157,3,0.0191,130,2,0.0154,27,1,0.037
+Prešovský,Stará Ľubovňa,Matysová,75,4,0.0533,110,1,0.0091,,,,,,,,,
+Prešovský,Stará Ľubovňa,Mníšek nad Popradom,246,4,0.0163,385,9,0.0234,119,0,0,102,0,0,17,0,0
+Prešovský,Stará Ľubovňa,Nižné Ružbachy,488,16,0.0328,443,5,0.0113,128,1,0.0078,99,0,0,29,1,0.0345
+Prešovský,Stará Ľubovňa,Nová Ľubovňa,1717,53,0.0309,1639,26,0.0159,665,9,0.0135,610,8,0.0131,55,1,0.0182
+Prešovský,Stará Ľubovňa,Obručné,27,4,0.1481,,,,,,,,,,,,
+Prešovský,Stará Ľubovňa,Orlov,487,6,0.0123,439,2,0.0046,,,,,,,,,
+Prešovský,Stará Ľubovňa,Plaveč,825,20,0.0242,896,7,0.0078,,,,,,,,,
+Prešovský,Stará Ľubovňa,Plavnica,888,27,0.0304,913,10,0.011,413,13,0.0315,368,12,0.0326,45,1,0.0222
+Prešovský,Stará Ľubovňa,Podolínec,1769,40,0.0226,1457,9,0.0062,,,,,,,,,
+Prešovský,Stará Ľubovňa,Pusté Pole,122,6,0.0492,107,2,0.0187,28,0,0,23,0,0,5,0,0
+Prešovský,Stará Ľubovňa,Ruská Voľa nad Popradom,104,7,0.0673,108,0,0,,,,,,,,,
+Prešovský,Stará Ľubovňa,Stará Ľubovňa,8009,173,0.0216,7593,101,0.0133,2801,63,0.0225,2527,50,0.0198,274,13,0.0474
+Prešovský,Stará Ľubovňa,Starina,148,4,0.027,132,1,0.0076,,,,,,,,,
+Prešovský,Stará Ľubovňa,Stráňany,94,5,0.0532,114,0,0,,,,,,,,,
+Prešovský,Stará Ľubovňa,Sulín,149,5,0.0336,160,0,0,,,,,,,,,
+Prešovský,Stará Ľubovňa,Šambron,205,5,0.0244,204,5,0.0245,91,2,0.022,85,2,0.0235,6,0,0
+Prešovský,Stará Ľubovňa,Šarišské Jastrabie,677,22,0.0325,718,3,0.0042,,,,,,,,,
+Prešovský,Stará Ľubovňa,Údol,207,5,0.0242,177,2,0.0113,64,1,0.0156,53,0,0,11,1,0.0909
+Prešovský,Stará Ľubovňa,Veľká Lesná,345,14,0.0406,296,1,0.0034,,,,,,,,,
+Prešovský,Stará Ľubovňa,Veľký Lipník,506,10,0.0198,473,8,0.0169,164,8,0.0488,134,7,0.0522,30,1,0.0333
+Prešovský,Stará Ľubovňa,Vislanka,324,9,0.0278,250,2,0.008,,,,,,,,,
+Prešovský,Stará Ľubovňa,Vyšné Ružbachy,666,5,0.0075,643,4,0.0062,,,,,,,,,
+Prešovský,Stropkov,Baňa,85,4,0.0471,103,0,0,,,,,,,,,
+Prešovský,Stropkov,Breznica,525,5,0.0095,521,3,0.0058,,,,,,,,,
+Prešovský,Stropkov,Breznička,119,1,0.0084,113,0,0,,,,,,,,,
+Prešovský,Stropkov,Brusnica,162,3,0.0185,157,1,0.0064,,,,,,,,,
+Prešovský,Stropkov,Bukovce,202,0,0,220,1,0.0045,,,,,,,,,
+Prešovský,Stropkov,Bystrá,0,0,0,,,,,,,,,,,,
+Prešovský,Stropkov,Bžany,135,1,0.0074,164,0,0,,,,,,,,,
+Prešovský,Stropkov,Duplín,160,0,0,157,1,0.0064,,,,,,,,,
+Prešovský,Stropkov,Gribov,177,5,0.0282,129,1,0.0078,,,,,,,,,
+Prešovský,Stropkov,Havaj,263,7,0.0266,292,2,0.0068,,,,,,,,,
+Prešovský,Stropkov,Chotča,456,15,0.0329,417,1,0.0024,,,,,,,,,
+Prešovský,Stropkov,Jakušovce,31,1,0.0323,28,0,0,,,,,,,,,
+Prešovský,Stropkov,Kolbovce,155,0,0,163,0,0,,,,,,,,,
+Prešovský,Stropkov,Korunková,60,0,0,63,1,0.0159,12,0,0,9,0,0,3,0,0
+Prešovský,Stropkov,Kožuchovce,43,0,0,47,0,0,,,,,,,,,
+Prešovský,Stropkov,Krišľovce,23,0,0,31,0,0,,,,,,,,,
+Prešovský,Stropkov,Kručov,171,8,0.0468,173,0,0,,,,,,,,,
+Prešovský,Stropkov,Krušinec,93,0,0,118,0,0,,,,,,,,,
+Prešovský,Stropkov,Lomné,237,1,0.0042,170,3,0.0176,50,0,0,43,0,0,7,0,0
+Prešovský,Stropkov,Makovce,111,0,0,116,0,0,,,,,,,,,
+Prešovský,Stropkov,Malá Poľana,61,3,0.0492,58,0,0,,,,,,,,,
+Prešovský,Stropkov,Miková,79,0,0,90,0,0,,,,,,,,,
+Prešovský,Stropkov,Miňovce,200,0,0,208,3,0.0144,85,4,0.0471,68,0,0,17,4,0.2353
+Prešovský,Stropkov,Mrázovce,0,0,0,,,,,,,,,,,,
+Prešovský,Stropkov,Nižná Olšava,278,1,0.0036,268,4,0.0149,50,0,0,48,0,0,2,0,0
+Prešovský,Stropkov,Oľšavka,116,4,0.0345,159,0,0,,,,,,,,,
+Prešovský,Stropkov,Potoky,125,2,0.016,120,1,0.0083,,,,,,,,,
+Prešovský,Stropkov,Potôčky,103,0,0,84,0,0,,,,,,,,,
+Prešovský,Stropkov,Soľník,29,0,0,33,0,0,,,,,,,,,
+Prešovský,Stropkov,Staškovce,192,2,0.0104,196,0,0,,,,,,,,,
+Prešovský,Stropkov,Stropkov,4136,46,0.0111,4527,26,0.0057,,,,,,,,,
+Prešovský,Stropkov,Šandal,264,3,0.0114,215,2,0.0093,,,,,,,,,
+Prešovský,Stropkov,Tisinec,270,2,0.0074,308,3,0.0097,,,,,,,,,
+Prešovský,Stropkov,Tokajík,109,0,0,97,0,0,,,,,,,,,
+Prešovský,Stropkov,Turany nad Ondavou,198,0,0,202,0,0,,,,,,,,,
+Prešovský,Stropkov,Varechovce,95,1,0.0105,85,1,0.0118,30,0,0,29,0,0,1,0,0
+Prešovský,Stropkov,Veľkrop,141,1,0.0071,147,1,0.0068,,,,,,,,,
+Prešovský,Stropkov,Vislava,111,0,0,126,0,0,,,,,,,,,
+Prešovský,Stropkov,Vladiča,40,1,0.025,44,1,0.0227,13,0,0,4,0,0,9,0,0
+Prešovský,Stropkov,Vojtovce,137,0,0,59,2,0.0339,19,0,0,15,0,0,4,0,0
+Prešovský,Stropkov,Vyškovce,122,2,0.0164,108,3,0.0278,17,0,0,9,0,0,8,0,0
+Prešovský,Stropkov,Vyšná Olšava,356,6,0.0169,346,2,0.0058,,,,,,,,,
+Prešovský,Stropkov,Vyšný Hrabovec,124,0,0,102,0,0,,,,,,,,,
+Prešovský,Svidník,Belejovce,59,0,0,10,0,0,,,,,,,,,
+Prešovský,Svidník,Beňadikovce,88,1,0.0114,86,1,0.0116,13,0,0,10,0,0,3,0,0
+Prešovský,Svidník,Bodružal,48,0,0,81,0,0,,,,,,,,,
+Prešovský,Svidník,Cernina,325,10,0.0308,333,0,0,,,,,,,,,
+Prešovský,Svidník,Cigla,145,4,0.0276,113,0,0,,,,,,,,,
+Prešovský,Svidník,Dlhoňa,61,0,0,62,0,0,,,,,,,,,
+Prešovský,Svidník,Dobroslava,32,0,0,34,0,0,,,,,,,,,
+Prešovský,Svidník,Dubová,80,0,0,126,2,0.0159,23,0,0,19,0,0,4,0,0
+Prešovský,Svidník,Dukovce,138,6,0.0435,139,0,0,,,,,,,,,
+Prešovský,Svidník,Fijaš,173,0,0,169,3,0.0178,68,5,0.0735,38,0,0,30,5,0.1667
+Prešovský,Svidník,Giraltovce,1978,20,0.0101,2139,11,0.0051,,,,,,,,,
+Prešovský,Svidník,Havranec,14,0,0,14,0,0,,,,,,,,,
+Prešovský,Svidník,Hrabovčík,148,0,0,140,0,0,,,,,,,,,
+Prešovský,Svidník,Hunkovce,211,2,0.0095,199,1,0.005,,,,,,,,,
+Prešovský,Svidník,Jurkova Voľa,50,0,0,49,2,0.0408,7,0,0,5,0,0,2,0,0
+Prešovský,Svidník,Kalnište,271,8,0.0295,275,4,0.0145,160,6,0.0375,122,1,0.0082,38,5,0.1316
+Prešovský,Svidník,Kapišová,74,4,0.0541,224,0,0,,,,,,,,,
+Prešovský,Svidník,Kečkovce,167,5,0.0299,159,0,0,,,,,,,,,
+Prešovský,Svidník,Kobylnice,219,2,0.0091,155,1,0.0065,,,,,,,,,
+Prešovský,Svidník,Korejovce,63,0,0,57,0,0,,,,,,,,,
+Prešovský,Svidník,Kračúnovce,579,7,0.0121,663,3,0.0045,,,,,,,,,
+Prešovský,Svidník,Krajná Bystrá,274,1,0.0036,277,1,0.0036,,,,,,,,,
+Prešovský,Svidník,Krajná Poľana,199,1,0.005,70,0,0,,,,,,,,,
+Prešovský,Svidník,Krajná Porúbka,88,1,0.0114,36,0,0,,,,,,,,,
+Prešovský,Svidník,Krajné Čierno,94,1,0.0106,71,0,0,,,,,,,,,
+Prešovský,Svidník,Kružlová,412,9,0.0218,393,2,0.0051,,,,,,,,,
+Prešovský,Svidník,Kuková,434,9,0.0207,426,2,0.0047,,,,,,,,,
+Prešovský,Svidník,Kurimka,158,3,0.019,178,0,0,,,,,,,,,
+Prešovský,Svidník,Ladomirová,499,3,0.006,417,0,0,,,,,,,,,
+Prešovský,Svidník,Lúčka,388,6,0.0155,336,2,0.006,,,,,,,,,
+Prešovský,Svidník,Lužany pri Topli,198,0,0,193,1,0.0052,,,,,,,,,
+Prešovský,Svidník,Matovce,49,3,0.0612,57,0,0,,,,,,,,,
+Prešovský,Svidník,Medvedie,11,0,0,29,0,0,,,,,,,,,
+Prešovský,Svidník,Mestisko,234,3,0.0128,243,1,0.0041,,,,,,,,,
+Prešovský,Svidník,Mičakovce,228,9,0.0395,200,0,0,,,,,,,,,
+Prešovský,Svidník,Miroľa,35,0,0,31,0,0,,,,,,,,,
+Prešovský,Svidník,Mlynárovce,42,0,0,94,0,0,,,,,,,,,
+Prešovský,Svidník,Nižná Jedľová,113,0,0,115,0,0,,,,,,,,,
+Prešovský,Svidník,Nižná Pisaná,78,2,0.0256,60,0,0,,,,,,,,,
+Prešovský,Svidník,Nižný Komárnik,103,3,0.0291,93,0,0,,,,,,,,,
+Prešovský,Svidník,Nižný Mirošov,168,1,0.006,127,2,0.0157,11,0,0,7,0,0,4,0,0
+Prešovský,Svidník,Nižný Orlík,112,1,0.0089,114,0,0,,,,,,,,,
+Prešovský,Svidník,Nová Polianka,94,0,0,118,2,0.0169,13,0,0,5,0,0,8,0,0
+Prešovský,Svidník,Okrúhle,326,1,0.0031,339,1,0.0029,,,,,,,,,
+Prešovský,Svidník,Príkra,8,0,0,26,0,0,,,,,,,,,
+Prešovský,Svidník,Pstriná,82,0,0,76,3,0.0395,16,2,0.125,8,2,0.25,8,0,0
+Prešovský,Svidník,Radoma,291,4,0.0137,262,1,0.0038,,,,,,,,,
+Prešovský,Svidník,Rakovčík,78,0,0,70,0,0,,,,,,,,,
+Prešovský,Svidník,Rovné,338,1,0.003,278,2,0.0072,,,,,,,,,
+Prešovský,Svidník,Roztoky,176,1,0.0057,194,2,0.0103,9,0,0,6,0,0,3,0,0
+Prešovský,Svidník,Soboš,169,2,0.0118,127,0,0,,,,,,,,,
+Prešovský,Svidník,Stročín,186,1,0.0054,187,1,0.0053,,,,,,,,,
+Prešovský,Svidník,Svidnička,49,0,0,73,0,0,,,,,,,,,
+Prešovský,Svidník,Svidník,4173,52,0.0125,4400,29,0.0066,,,,,,,,,
+Prešovský,Svidník,Šarbov,34,0,0,27,0,0,,,,,,,,,
+Prešovský,Svidník,Šarišský Štiavnik,118,4,0.0339,112,1,0.0089,,,,,,,,,
+Prešovský,Svidník,Šemetkovce,110,0,0,94,0,0,,,,,,,,,
+Prešovský,Svidník,Štefurov,83,0,0,89,0,0,,,,,,,,,
+Prešovský,Svidník,Vagrinec,78,0,0,83,0,0,,,,,,,,,
+Prešovský,Svidník,Valkovce,164,4,0.0244,138,1,0.0072,,,,,,,,,
+Prešovský,Svidník,Vápeník,81,0,0,74,0,0,,,,,,,,,
+Prešovský,Svidník,Vyšná Jedľová,106,1,0.0094,135,0,0,,,,,,,,,
+Prešovský,Svidník,Vyšná Pisaná,78,0,0,66,0,0,,,,,,,,,
+Prešovský,Svidník,Vyšný Komárnik,44,0,0,40,0,0,,,,,,,,,
+Prešovský,Svidník,Vyšný Mirošov,310,5,0.0161,304,2,0.0066,,,,,,,,,
+Prešovský,Svidník,Vyšný Orlík,267,14,0.0524,230,1,0.0043,,,,,,,,,
+Prešovský,Svidník,Železník,189,0,0,208,0,0,,,,,,,,,
+Prešovský,Svidník,Želmanovce,159,5,0.0314,168,0,0,,,,,,,,,
+Prešovský,Vranov nad Topľou,Banské,1072,9,0.0084,1016,6,0.0059,,,,,,,,,
+Prešovský,Vranov nad Topľou,Benkovce,391,4,0.0102,365,5,0.0137,117,2,0.0171,58,0,0,59,2,0.0339
+Prešovský,Vranov nad Topľou,Bystré,1500,12,0.008,1498,3,0.002,,,,,,,,,
+Prešovský,Vranov nad Topľou,Cabov,353,0,0,513,0,0,,,,,,,,,
+Prešovský,Vranov nad Topľou,Čaklov,1052,12,0.0114,1319,7,0.0053,,,,,,,,,
+Prešovský,Vranov nad Topľou,Čičava,766,2,0.0026,731,0,0,,,,,,,,,
+Prešovský,Vranov nad Topľou,Čierne nad Topľou,457,0,0,498,0,0,,,,,,,,,
+Prešovský,Vranov nad Topľou,Ďapalovce,393,4,0.0102,372,0,0,,,,,,,,,
+Prešovský,Vranov nad Topľou,Davidov,496,2,0.004,520,2,0.0038,,,,,,,,,
+Prešovský,Vranov nad Topľou,Dlhé Klčovo,704,11,0.0156,768,2,0.0026,,,,,,,,,
+Prešovský,Vranov nad Topľou,Hanušovce nad Topľou,1826,18,0.0099,1844,15,0.0081,,,,,,,,,
+Prešovský,Vranov nad Topľou,Hencovce,912,9,0.0099,878,7,0.008,,,,,,,,,
+Prešovský,Vranov nad Topľou,Hermanovce nad Topľou,520,2,0.0038,523,0,0,,,,,,,,,
+Prešovský,Vranov nad Topľou,Hlinné,1236,8,0.0065,1233,15,0.0122,339,8,0.0236,277,3,0.0108,62,5,0.0806
+Prešovský,Vranov nad Topľou,Holčíkovce,509,3,0.0059,535,0,0,,,,,,,,,
+Prešovský,Vranov nad Topľou,Jastrabie nad Topľou,377,1,0.0027,368,1,0.0027,,,,,,,,,
+Prešovský,Vranov nad Topľou,Kamenná Poruba,494,5,0.0101,857,1,0.0012,,,,,,,,,
+Prešovský,Vranov nad Topľou,Kladzany,401,3,0.0075,457,1,0.0022,,,,,,,,,
+Prešovský,Vranov nad Topľou,Komárany,509,10,0.0196,389,3,0.0077,,,,,,,,,
+Prešovský,Vranov nad Topľou,Kučín,496,5,0.0101,410,0,0,,,,,,,,,
+Prešovský,Vranov nad Topľou,Kvakovce,378,5,0.0132,382,2,0.0052,,,,,,,,,
+Prešovský,Vranov nad Topľou,Majerovce,477,14,0.0294,422,1,0.0024,,,,,,,,,
+Prešovský,Vranov nad Topľou,Malá Domaša,394,3,0.0076,377,1,0.0027,,,,,,,,,
+Prešovský,Vranov nad Topľou,Matiaška,498,2,0.004,500,8,0.016,80,4,0.05,68,4,0.0588,12,0,0
+Prešovský,Vranov nad Topľou,Merník,570,3,0.0053,567,1,0.0018,,,,,,,,,
+Prešovský,Vranov nad Topľou,Nižný Hrabovec,601,13,0.0216,724,5,0.0069,,,,,,,,,
+Prešovský,Vranov nad Topľou,Nižný Hrušov,967,27,0.0279,861,7,0.0081,,,,,,,,,
+Prešovský,Vranov nad Topľou,Nižný Kručov,463,10,0.0216,432,7,0.0162,166,11,0.0663,58,0,0,108,11,0.1019
+Prešovský,Vranov nad Topľou,Nová Kelča,292,0,0,292,0,0,,,,,,,,,
+Prešovský,Vranov nad Topľou,Ondavské Matiašovce,529,2,0.0038,533,1,0.0019,,,,,,,,,
+Prešovský,Vranov nad Topľou,Pavlovce,634,6,0.0095,659,7,0.0106,213,6,0.0282,186,6,0.0323,27,0,0
+Prešovský,Vranov nad Topľou,Petrovce,450,2,0.0044,422,5,0.0118,152,5,0.0329,103,5,0.0485,49,0,0
+Prešovský,Vranov nad Topľou,Poša,555,3,0.0054,581,2,0.0034,,,,,,,,,
+Prešovský,Vranov nad Topľou,Rudlov,503,8,0.0159,460,2,0.0043,,,,,,,,,
+Prešovský,Vranov nad Topľou,Sačurov,1389,6,0.0043,1560,7,0.0045,,,,,,,,,
+Prešovský,Vranov nad Topľou,Sečovská Polianka,1295,4,0.0031,1450,13,0.009,,,,,,,,,
+Prešovský,Vranov nad Topľou,Sedliská,769,6,0.0078,768,3,0.0039,,,,,,,,,
+Prešovský,Vranov nad Topľou,Skrabské,455,4,0.0088,473,0,0,,,,,,,,,
+Prešovský,Vranov nad Topľou,Slovenská Kajňa,462,1,0.0022,475,4,0.0084,,,,,,,,,
+Prešovský,Vranov nad Topľou,Soľ,1516,12,0.0079,1491,1,0.0007,,,,,,,,,
+Prešovský,Vranov nad Topľou,Tovarné,730,7,0.0096,755,6,0.0079,,,,,,,,,
+Prešovský,Vranov nad Topľou,Vechec,1945,10,0.0051,1022,2,0.002,,,,,,,,,
+Prešovský,Vranov nad Topľou,Vlača,600,6,0.01,621,15,0.0242,161,4,0.0248,137,3,0.0219,24,1,0.0417
+Prešovský,Vranov nad Topľou,Vranov nad Topľou,9495,113,0.0119,10484,62,0.0059,,,,,,,,,
+Prešovský,Vranov nad Topľou,Vyšný Žipov,758,3,0.004,785,4,0.0051,,,,,,,,,
+Prešovský,Vranov nad Topľou,Zámutov,1864,57,0.0306,1714,39,0.0228,589,14,0.0238,527,10,0.019,62,4,0.0645
+Prešovský,Vranov nad Topľou,Žalobín,499,13,0.0261,486,1,0.0021,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Bánovce nad Bebravou,8839,168,0.019,9201,82,0.0089,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Borčany,428,11,0.0257,289,0,0,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Brezolupy,239,7,0.0293,231,3,0.013,100,1,0.01,67,1,0.0149,33,0,0
+Trenčiansky,Bánovce nad Bebravou,Cimenná,74,0,0,83,0,0,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Čierna Lehota,219,7,0.032,228,8,0.0351,0,0,0,0,0,0,0,0,0
+Trenčiansky,Bánovce nad Bebravou,Dežerice,682,17,0.0249,682,4,0.0059,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Dolné Naštice,714,13,0.0182,511,2,0.0039,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Dubnička,99,1,0.0101,111,0,0,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Dvorec,187,6,0.0321,199,0,0,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Haláčovce,197,1,0.0051,217,2,0.0092,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Horné Naštice,435,6,0.0138,374,2,0.0053,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Chudá Lehota,180,3,0.0167,191,0,0,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Krásna Ves,422,4,0.0095,388,2,0.0052,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Kšinná,471,16,0.034,468,6,0.0128,145,0,0,117,0,0,28,0,0
+Trenčiansky,Bánovce nad Bebravou,Libichava,92,1,0.0109,106,0,0,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Ľutov,220,2,0.0091,221,2,0.009,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Malá Hradná,236,7,0.0297,217,1,0.0046,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Malé Hoste,157,5,0.0318,147,0,0,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Miezgovce,160,6,0.0375,142,0,0,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Nedašovce,516,13,0.0252,282,7,0.0248,33,0,0,22,0,0,11,0,0
+Trenčiansky,Bánovce nad Bebravou,Omastiná,10,0,0,30,0,0,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Otrhánky,410,5,0.0122,329,1,0.003,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Pečeňany,191,2,0.0105,240,1,0.0042,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Podlužany,724,23,0.0318,656,2,0.003,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Pochabany,241,13,0.0539,227,1,0.0044,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Pravotice,387,4,0.0103,310,10,0.0323,75,0,0,50,0,0,25,0,0
+Trenčiansky,Bánovce nad Bebravou,Prusy,509,7,0.0138,241,2,0.0083,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Ruskovce,503,5,0.0099,489,5,0.0102,95,4,0.0421,73,0,0,22,4,0.1818
+Trenčiansky,Bánovce nad Bebravou,Rybany,610,14,0.023,795,9,0.0113,215,3,0.014,162,2,0.0123,53,1,0.0189
+Trenčiansky,Bánovce nad Bebravou,Slatina nad Bebravou,205,3,0.0146,206,4,0.0194,59,0,0,41,0,0,18,0,0
+Trenčiansky,Bánovce nad Bebravou,Slatinka nad Bebravou,123,3,0.0244,130,2,0.0154,45,0,0,24,0,0,21,0,0
+Trenčiansky,Bánovce nad Bebravou,Šípkov,383,10,0.0261,346,2,0.0058,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Šišov,410,5,0.0122,366,0,0,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Timoradza,273,2,0.0073,278,0,0,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Trebichava,0,0,0,,,,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Uhrovec,1038,21,0.0202,969,10,0.0103,317,3,0.0095,253,0,0,64,3,0.0469
+Trenčiansky,Bánovce nad Bebravou,Uhrovské Podhradie,413,12,0.0291,411,1,0.0024,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Veľké Držkovce,465,8,0.0172,475,3,0.0063,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Veľké Hoste,403,8,0.0199,393,7,0.0178,66,0,0,54,0,0,12,0,0
+Trenčiansky,Bánovce nad Bebravou,Veľké Chlievany,642,8,0.0125,435,8,0.0184,114,5,0.0439,63,0,0,51,5,0.098
+Trenčiansky,Bánovce nad Bebravou,Vysočany,75,2,0.0267,82,0,0,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Zlatníky,517,6,0.0116,478,3,0.0063,,,,,,,,,
+Trenčiansky,Bánovce nad Bebravou,Žitná - Radiša,29,0,0,74,0,0,,,,,,,,,
+Trenčiansky,Ilava,Bohunice,539,8,0.0148,521,2,0.0038,,,,,,,,,
+Trenčiansky,Ilava,Bolešov,1178,9,0.0076,1063,9,0.0085,,,,,,,,,
+Trenčiansky,Ilava,Borčice,605,3,0.005,558,1,0.0018,,,,,,,,,
+Trenčiansky,Ilava,Červený Kameň,543,11,0.0203,495,5,0.0101,149,4,0.0268,111,3,0.027,38,1,0.0263
+Trenčiansky,Ilava,Dubnica nad Váhom,13370,149,0.0111,13513,113,0.0084,,,,,,,,,
+Trenčiansky,Ilava,Dulov,677,12,0.0177,652,6,0.0092,,,,,,,,,
+Trenčiansky,Ilava,Horná Poruba,685,18,0.0263,701,5,0.0071,,,,,,,,,
+Trenčiansky,Ilava,Ilava,3484,44,0.0126,3552,46,0.013,1010,39,0.0386,654,14,0.0214,356,25,0.0702
+Trenčiansky,Ilava,Kameničany,270,1,0.0037,307,1,0.0033,,,,,,,,,
+Trenčiansky,Ilava,Košeca,2597,29,0.0112,1333,21,0.0158,338,10,0.0296,280,10,0.0357,58,0,0
+Trenčiansky,Ilava,Košecké Podhradie,768,12,0.0156,729,3,0.0041,,,,,,,,,
+Trenčiansky,Ilava,Krivoklát,177,1,0.0056,181,4,0.0221,51,3,0.0588,34,1,0.0294,17,2,0.1176
+Trenčiansky,Ilava,Ladce,1659,26,0.0157,1669,17,0.0102,531,12,0.0226,477,8,0.0168,54,4,0.0741
+Trenčiansky,Ilava,Mikušovce,799,4,0.005,697,1,0.0014,,,,,,,,,
+Trenčiansky,Ilava,Nová Dubnica,6417,72,0.0112,6435,28,0.0044,,,,,,,,,
+Trenčiansky,Ilava,Pruské,1631,12,0.0074,1613,9,0.0056,,,,,,,,,
+Trenčiansky,Ilava,Sedmerovec,241,3,0.0124,233,4,0.0172,121,5,0.0413,89,2,0.0225,32,3,0.0938
+Trenčiansky,Ilava,Slavnica,800,11,0.0138,465,7,0.0151,330,24,0.0727,177,5,0.0282,153,19,0.1242
+Trenčiansky,Ilava,Tuchyňa,589,11,0.0187,602,5,0.0083,,,,,,,,,
+Trenčiansky,Ilava,Vršatské Podhradie,165,1,0.0061,156,1,0.0064,,,,,,,,,
+Trenčiansky,Ilava,Zliechov,410,5,0.0122,456,3,0.0066,,,,,,,,,
+Trenčiansky,Myjava,Brestovec,581,8,0.0138,617,2,0.0032,,,,,,,,,
+Trenčiansky,Myjava,Brezová pod Bradlom,2928,23,0.0079,3252,6,0.0018,,,,,,,,,
+Trenčiansky,Myjava,Bukovec,388,0,0,382,0,0,,,,,,,,,
+Trenčiansky,Myjava,Hrašné,267,0,0,276,0,0,,,,,,,,,
+Trenčiansky,Myjava,Chvojnica,222,2,0.009,240,2,0.0083,,,,,,,,,
+Trenčiansky,Myjava,Jablonka,237,3,0.0127,250,0,0,,,,,,,,,
+Trenčiansky,Myjava,Kostolné,697,5,0.0072,672,0,0,,,,,,,,,
+Trenčiansky,Myjava,Košariská,436,3,0.0069,496,2,0.004,,,,,,,,,
+Trenčiansky,Myjava,Krajné,1022,12,0.0117,1200,8,0.0067,,,,,,,,,
+Trenčiansky,Myjava,Myjava,6995,53,0.0076,7292,35,0.0048,,,,,,,,,
+Trenčiansky,Myjava,Podkylava,547,1,0.0018,516,3,0.0058,,,,,,,,,
+Trenčiansky,Myjava,Polianka,349,0,0,357,3,0.0084,,,,,,,,,
+Trenčiansky,Myjava,Poriadie,545,7,0.0128,498,2,0.004,,,,,,,,,
+Trenčiansky,Myjava,Priepasné,221,1,0.0045,212,0,0,,,,,,,,,
+Trenčiansky,Myjava,Rudník,676,7,0.0104,662,1,0.0015,,,,,,,,,
+Trenčiansky,Myjava,Stará Myjava,533,12,0.0225,635,1,0.0016,,,,,,,,,
+Trenčiansky,Myjava,Vrbovce,1109,2,0.0018,1042,3,0.0029,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Beckov,1034,8,0.0077,1127,2,0.0018,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Bošáca,749,4,0.0053,743,1,0.0013,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Brunovce,530,19,0.0358,786,9,0.0115,180,12,0.0667,86,2,0.0233,94,10,0.1064
+Trenčiansky,Nové Mesto nad Váhom,Bzince pod Javorinou,1346,4,0.003,1291,3,0.0023,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Čachtice,2378,36,0.0151,2699,15,0.0056,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Častkovce,1064,4,0.0038,996,5,0.005,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Dolné Srnie,708,5,0.0071,714,5,0.007,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Haluzice,418,2,0.0048,155,1,0.0065,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Horná Streda,910,8,0.0088,2144,10,0.0047,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Hôrka nad Váhom,718,2,0.0028,659,2,0.003,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Hrádok,642,0,0,756,0,0,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Hrachovište,530,11,0.0208,566,7,0.0124,283,14,0.0495,123,4,0.0325,160,10,0.0625
+Trenčiansky,Nové Mesto nad Váhom,Kálnica,710,10,0.0141,727,3,0.0041,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Kočovce,1289,7,0.0054,1360,3,0.0022,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Lubina,1525,5,0.0033,1595,2,0.0013,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Lúka,530,9,0.017,771,3,0.0039,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Modrová,485,4,0.0082,471,0,0,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Modrovka,110,2,0.0182,349,1,0.0029,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Moravské Lieskové,1896,24,0.0127,1807,4,0.0022,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Nová Bošáca,821,6,0.0073,816,0,0,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Nová Lehota,271,2,0.0074,359,1,0.0028,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Nová Ves nad Váhom,278,0,0,308,1,0.0032,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Nové Mesto nad Váhom,10935,94,0.0086,11819,27,0.0023,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Očkov,515,4,0.0078,1222,13,0.0106,85,1,0.0118,37,0,0,48,1,0.0208
+Trenčiansky,Nové Mesto nad Váhom,Pobedim,832,3,0.0036,1235,6,0.0049,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Podolie,1098,7,0.0064,1424,5,0.0035,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Potvorice,771,4,0.0052,996,6,0.006,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Považany,898,12,0.0134,985,7,0.0071,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Stará Lehota,143,0,0,169,0,0,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Stará Turá,4656,49,0.0105,5190,45,0.0087,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Trenčianske Bohuslavice,491,5,0.0102,526,0,0,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Vaďovce,700,8,0.0114,643,6,0.0093,,,,,,,,,
+Trenčiansky,Nové Mesto nad Váhom,Višňové,137,0,0,150,2,0.0133,95,3,0.0316,36,0,0,59,3,0.0508
+Trenčiansky,Nové Mesto nad Váhom,Zemianske Podhradie,711,5,0.007,711,3,0.0042,,,,,,,,,
+Trenčiansky,Partizánske,Bošany,2336,26,0.0111,2563,11,0.0043,,,,,,,,,
+Trenčiansky,Partizánske,Brodzany,594,6,0.0101,643,2,0.0031,,,,,,,,,
+Trenčiansky,Partizánske,Hradište,646,8,0.0124,637,7,0.011,174,6,0.0345,127,1,0.0079,47,5,0.1064
+Trenčiansky,Partizánske,Chynorany,1428,19,0.0133,1560,10,0.0064,,,,,,,,,
+Trenčiansky,Partizánske,Ježková Ves,219,1,0.0046,416,3,0.0072,,,,,,,,,
+Trenčiansky,Partizánske,Klátová nová Ves,1073,11,0.0103,1268,6,0.0047,,,,,,,,,
+Trenčiansky,Partizánske,Klížske Hradište + Veľký Klíž,616,6,0.0097,694,4,0.0058,,,,,,,,,
+Trenčiansky,Partizánske,Kolačno,529,8,0.0151,574,11,0.0192,152,2,0.0132,122,1,0.0082,30,1,0.0333
+Trenčiansky,Partizánske,Krásno,710,18,0.0254,528,2,0.0038,,,,,,,,,
+Trenčiansky,Partizánske,Livinské Opatovce,137,8,0.0584,184,1,0.0054,,,,,,,,,
+Trenčiansky,Partizánske,Malé Bielice,174,4,0.023,214,2,0.0093,,,,,,,,,
+Trenčiansky,Partizánske,Malé Krštenany,650,10,0.0154,535,9,0.0168,80,2,0.025,45,0,0,35,2,0.0571
+Trenčiansky,Partizánske,Malé Uherce,610,7,0.0115,698,6,0.0086,,,,,,,,,
+Trenčiansky,Partizánske,Nadlice,691,16,0.0232,629,3,0.0048,,,,,,,,,
+Trenčiansky,Partizánske,Návojovce,445,7,0.0157,403,3,0.0074,,,,,,,,,
+Trenčiansky,Partizánske,Nedanovce,480,6,0.0125,489,1,0.002,,,,,,,,,
+Trenčiansky,Partizánske,Ostratice,607,6,0.0099,589,3,0.0051,,,,,,,,,
+Trenčiansky,Partizánske,Partizánske,10192,231,0.0227,10932,81,0.0074,,,,,,,,,
+Trenčiansky,Partizánske,Pažiť,656,16,0.0244,404,5,0.0124,19,0,0,17,0,0,2,0,0
+Trenčiansky,Partizánske,Skačany,824,9,0.0109,805,1,0.0012,,,,,,,,,
+Trenčiansky,Partizánske,Veľké Krštenany,470,18,0.0383,348,4,0.0115,83,0,0,69,0,0,14,0,0
+Trenčiansky,Partizánske,Veľké Uherce,1269,24,0.0189,1397,8,0.0057,,,,,,,,,
+Trenčiansky,Partizánske,Žabokreky n/N,1003,25,0.0249,1075,3,0.0028,,,,,,,,,
+Trenčiansky,Považská Bystrica,Bodiná,270,1,0.0037,279,1,0.0036,,,,,,,,,
+Trenčiansky,Považská Bystrica,Brvnište,857,16,0.0187,780,9,0.0115,193,3,0.0155,177,3,0.0169,16,0,0
+Trenčiansky,Považská Bystrica,Čelkova Lehota,175,3,0.0171,152,2,0.0132,63,0,0,63,0,0,0,0,0
+Trenčiansky,Považská Bystrica,Dolná Mariková,984,9,0.0091,969,11,0.0114,248,6,0.0242,179,2,0.0112,69,4,0.058
+Trenčiansky,Považská Bystrica,Dolný Lieskov,487,5,0.0103,475,3,0.0063,,,,,,,,,
+Trenčiansky,Považská Bystrica,Domaniža,1283,38,0.0296,1131,7,0.0062,,,,,,,,,
+Trenčiansky,Považská Bystrica,Ďurďové,359,4,0.0111,280,4,0.0143,40,1,0.025,15,0,0,25,1,0.04
+Trenčiansky,Považská Bystrica,Hatné,501,12,0.024,443,4,0.009,,,,,,,,,
+Trenčiansky,Považská Bystrica,Horná Mariková,665,2,0.003,688,4,0.0058,,,,,,,,,
+Trenčiansky,Považská Bystrica,Horný Lieskov,199,6,0.0302,210,0,0,,,,,,,,,
+Trenčiansky,Považská Bystrica,Jasenica,894,17,0.019,848,9,0.0106,292,9,0.0308,222,6,0.027,70,3,0.0429
+Trenčiansky,Považská Bystrica,Klieština,150,5,0.0333,169,2,0.0118,27,0,0,19,0,0,8,0,0
+Trenčiansky,Považská Bystrica,KOSTOLEC,339,8,0.0236,240,1,0.0042,,,,,,,,,
+Trenčiansky,Považská Bystrica,Malé Lednice,385,23,0.0597,328,2,0.0061,,,,,,,,,
+Trenčiansky,Považská Bystrica,Papradno,1360,26,0.0191,1362,21,0.0154,398,6,0.0151,334,4,0.012,64,2,0.0313
+Trenčiansky,Považská Bystrica,PLEVNÍK-DRIENOVÉ,1232,20,0.0162,1042,9,0.0086,,,,,,,,,
+Trenčiansky,Považská Bystrica,Počarová,358,3,0.0084,255,1,0.0039,,,,,,,,,
+Trenčiansky,Považská Bystrica,Podskalie,1005,0,0,117,1,0.0085,,,,,,,,,
+Trenčiansky,Považská Bystrica,Považská Bystrica,19999,208,0.0104,20361,178,0.0087,,,,,,,,,
+Trenčiansky,Považská Bystrica,Prečín,1099,11,0.01,1062,11,0.0104,332,11,0.0331,248,0,0,84,11,0.131
+Trenčiansky,Považská Bystrica,Pružina,1401,31,0.0221,1275,14,0.011,448,3,0.0067,392,2,0.0051,56,1,0.0179
+Trenčiansky,Považská Bystrica,Sádočné,113,0,0,115,2,0.0174,62,1,0.0161,45,0,0,17,1,0.0588
+Trenčiansky,Považská Bystrica,Slopná,279,7,0.0251,261,1,0.0038,,,,,,,,,
+Trenčiansky,Považská Bystrica,Stupné,510,10,0.0196,538,6,0.0112,159,4,0.0252,129,2,0.0155,30,2,0.0667
+Trenčiansky,Považská Bystrica,Sverepec,1017,11,0.0108,1024,16,0.0156,352,12,0.0341,239,5,0.0209,113,7,0.0619
+Trenčiansky,Považská Bystrica,Udiča,1423,26,0.0183,1290,18,0.014,350,6,0.0171,277,3,0.0108,73,3,0.0411
+Trenčiansky,Považská Bystrica,Vrchteplá,155,0,0,151,2,0.0132,46,3,0.0652,35,1,0.0286,11,2,0.1818
+Trenčiansky,Považská Bystrica,Záskalie,323,3,0.0093,247,4,0.0162,57,0,0,52,0,0,5,0,0
+Trenčiansky,Prievidza,Bojnice,3247,57,0.0176,2991,12,0.004,,,,,,,,,
+Trenčiansky,Prievidza,Bystričnany,1184,35,0.0296,1173,5,0.0043,,,,,,,,,
+Trenčiansky,Prievidza,Cígeľ,1013,16,0.0158,883,6,0.0068,,,,,,,,,
+Trenčiansky,Prievidza,Čavoj,550,6,0.0109,596,3,0.005,,,,,,,,,
+Trenčiansky,Prievidza,Čereňany,1043,48,0.046,1011,12,0.0119,313,15,0.0479,207,6,0.029,106,9,0.0849
+Trenčiansky,Prievidza,Diviacka Nová Ves,963,31,0.0322,926,10,0.0108,260,2,0.0077,225,1,0.0044,35,1,0.0286
+Trenčiansky,Prievidza,Diviacká nová Ves,963,31,0.0322,926,10,0.0108,,,,,,,,,
+Trenčiansky,Prievidza,Diviaky nad Nitricou,1229,30,0.0244,1200,14,0.0117,280,3,0.0107,234,1,0.0043,46,2,0.0435
+Trenčiansky,Prievidza,Dolné Vestenice,1428,24,0.0168,1514,4,0.0026,,,,,,,,,
+Trenčiansky,Prievidza,Handlová,8697,131,0.0151,9248,73,0.0079,,,,,,,,,
+Trenčiansky,Prievidza,Horná Ves,734,13,0.0177,785,5,0.0064,,,,,,,,,
+Trenčiansky,Prievidza,Horné Vestenice,562,11,0.0196,539,2,0.0037,,,,,,,,,
+Trenčiansky,Prievidza,Hradec,357,8,0.0224,480,5,0.0104,213,11,0.0516,147,9,0.0612,66,2,0.0303
+Trenčiansky,Prievidza,Chrenovec-Brusno,1219,18,0.0148,898,7,0.0078,,,,,,,,,
+Trenčiansky,Prievidza,Chvojnica,179,0,0,216,3,0.0139,47,2,0.0426,22,1,0.0455,25,1,0.04
+Trenčiansky,Prievidza,Jalovec,632,17,0.0269,509,2,0.0039,,,,,,,,,
+Trenčiansky,Prievidza,Kamenec pod Vtáčnikom,1136,29,0.0255,1173,2,0.0017,,,,,,,,,
+Trenčiansky,Prievidza,Kanianka,1975,22,0.0111,1912,18,0.0094,,,,,,,,,
+Trenčiansky,Prievidza,Kľačno,693,10,0.0144,720,0,0,,,,,,,,,
+Trenčiansky,Prievidza,Kocurany,646,20,0.031,488,2,0.0041,,,,,,,,,
+Trenčiansky,Prievidza,Kostolná Ves,602,18,0.0299,471,3,0.0064,,,,,,,,,
+Trenčiansky,Prievidza,Koš,790,13,0.0165,776,7,0.009,,,,,,,,,
+Trenčiansky,Prievidza,Lazany,1017,28,0.0275,942,11,0.0117,452,16,0.0354,282,0,0,170,16,0.0941
+Trenčiansky,Prievidza,Lehota pod Vtáčnikom,2326,51,0.0219,2414,13,0.0054,,,,,,,,,
+Trenčiansky,Prievidza,Liešťany,681,19,0.0279,713,4,0.0056,,,,,,,,,
+Trenčiansky,Prievidza,Lipník,542,18,0.0332,422,7,0.0166,123,10,0.0813,60,0,0,63,10,0.1587
+Trenčiansky,Prievidza,Malá Čausa,548,13,0.0237,425,5,0.0118,98,2,0.0204,71,0,0,27,2,0.0741
+Trenčiansky,Prievidza,Malá Lehôtka,509,5,0.0098,335,5,0.0149,183,3,0.0164,160,3,0.0188,23,0,0
+Trenčiansky,Prievidza,Malinová,536,12,0.0224,584,2,0.0034,,,,,,,,,
+Trenčiansky,Prievidza,Nedožery- Brezany,1494,31,0.0207,1310,13,0.0099,,,,,,,,,
+Trenčiansky,Prievidza,Nevidzany,303,0,0,278,1,0.0036,,,,,,,,,
+Trenčiansky,Prievidza,Nitrianské Pravno,2018,21,0.0104,1966,9,0.0046,,,,,,,,,
+Trenčiansky,Prievidza,Nitrianské Rudno,785,21,0.0268,859,6,0.007,,,,,,,,,
+Trenčiansky,Prievidza,Nitrianské Súčany,740,15,0.0203,731,10,0.0137,260,2,0.0077,230,1,0.0043,30,1,0.0333
+Trenčiansky,Prievidza,Nitrica,875,10,0.0114,867,9,0.0104,211,1,0.0047,179,1,0.0056,32,0,0
+Trenčiansky,Prievidza,Nováky,2682,63,0.0235,2634,19,0.0072,,,,,,,,,
+Trenčiansky,Prievidza,Opatovce nad Nitrou,834,25,0.03,741,6,0.0081,,,,,,,,,
+Trenčiansky,Prievidza,Oslany,1138,23,0.0202,1182,4,0.0034,,,,,,,,,
+Trenčiansky,Prievidza,Poluvsie,534,11,0.0206,493,9,0.0183,234,7,0.0299,138,2,0.0145,96,5,0.0521
+Trenčiansky,Prievidza,Poruba,980,37,0.0378,829,9,0.0109,218,10,0.0459,175,6,0.0343,43,4,0.093
+Trenčiansky,Prievidza,Pravenec,1035,17,0.0164,920,8,0.0087,,,,,,,,,
+Trenčiansky,Prievidza,Prievidza,21101,419,0.0199,22640,187,0.0083,,,,,,,,,
+Trenčiansky,Prievidza,Radobica,478,11,0.023,482,4,0.0083,,,,,,,,,
+Trenčiansky,Prievidza,Ráztočno,804,20,0.0249,756,5,0.0066,,,,,,,,,
+Trenčiansky,Prievidza,Rudnianská Lehota,513,12,0.0234,458,1,0.0022,,,,,,,,,
+Trenčiansky,Prievidza,Sebedražie,1009,19,0.0188,1104,3,0.0027,,,,,,,,,
+Trenčiansky,Prievidza,Seč,226,0,0,253,1,0.004,,,,,,,,,
+Trenčiansky,Prievidza,Šútovce,239,9,0.0377,226,1,0.0044,,,,,,,,,
+Trenčiansky,Prievidza,Tužina,921,32,0.0347,846,1,0.0012,,,,,,,,,
+Trenčiansky,Prievidza,Valaská Belá,1265,24,0.019,1312,15,0.0114,242,0,0,216,0,0,26,0,0
+Trenčiansky,Prievidza,Veľká Čausa,404,6,0.0149,380,2,0.0053,,,,,,,,,
+Trenčiansky,Prievidza,Veľká Lehôtka,682,20,0.0293,668,4,0.006,,,,,,,,,
+Trenčiansky,Prievidza,Zemianske Kostoľany,857,16,0.0187,891,7,0.0079,,,,,,,,,
+Trenčiansky,Púchov,Beluša,3194,83,0.026,3181,43,0.0135,1392,36,0.0259,1256,33,0.0263,136,3,0.0221
+Trenčiansky,Púchov,Beluša - Hloža,428,5,0.0117,436,7,0.0161,307,4,0.013,152,4,0.0263,155,0,0
+Trenčiansky,Púchov,Beluša - Podhorie,275,1,0.0036,270,0,0,,,,,,,,,
+Trenčiansky,Púchov,Dohňany,1646,39,0.0237,1307,19,0.0145,532,3,0.0056,431,2,0.0046,101,1,0.0099
+Trenčiansky,Púchov,Dolná Breznica,507,20,0.0394,527,20,0.038,247,8,0.0324,213,8,0.0376,34,0,0
+Trenčiansky,Púchov,Dolné Kočkovce,642,33,0.0514,752,20,0.0266,351,4,0.0114,300,0,0,51,4,0.0784
+Trenčiansky,Púchov,Horná Breznica,207,6,0.029,193,3,0.0155,116,2,0.0172,106,2,0.0189,10,0,0
+Trenčiansky,Púchov,Horovce,603,36,0.0597,546,6,0.011,214,10,0.0467,154,6,0.039,60,4,0.0667
+Trenčiansky,Púchov,Kvašov,547,18,0.0329,485,10,0.0206,166,2,0.012,144,2,0.0139,22,0,0
+Trenčiansky,Púchov,Lazy pod Makytou,1086,35,0.0322,1081,16,0.0148,326,7,0.0215,242,5,0.0207,84,2,0.0238
+Trenčiansky,Púchov,Lednica,569,27,0.0475,532,10,0.0188,237,3,0.0127,220,3,0.0136,17,0,0
+Trenčiansky,Púchov,Lednické Rovne,3030,86,0.0284,2853,64,0.0224,1403,39,0.0278,1202,32,0.0266,201,7,0.0348
+Trenčiansky,Púchov,Lúky,915,22,0.024,835,10,0.012,259,10,0.0386,218,9,0.0413,41,1,0.0244
+Trenčiansky,Púchov,Lysá pod Makytou,1097,41,0.0374,1089,20,0.0184,485,8,0.0165,431,7,0.0162,54,1,0.0185
+Trenčiansky,Púchov,Mestečko,243,11,0.0453,245,6,0.0245,108,4,0.037,98,4,0.0408,10,0,0
+Trenčiansky,Púchov,Mojtín,435,6,0.0138,430,6,0.014,135,2,0.0148,105,2,0.019,30,0,0
+Trenčiansky,Púchov,Nimnica,739,17,0.023,689,12,0.0174,237,3,0.0127,170,3,0.0176,67,0,0
+Trenčiansky,Púchov,Púchov,10234,241,0.0235,9713,139,0.0143,4118,93,0.0226,3745,81,0.0216,373,12,0.0322
+Trenčiansky,Púchov,Streženice,721,18,0.025,749,7,0.0093,,,,,,,,,
+Trenčiansky,Púchov,Visolaje,629,16,0.0254,644,9,0.014,288,7,0.0243,257,6,0.0233,31,1,0.0323
+Trenčiansky,Púchov,Vydrná,441,5,0.0113,367,6,0.0163,103,4,0.0388,80,3,0.0375,23,1,0.0435
+Trenčiansky,Púchov,Záriečie,615,42,0.0683,485,11,0.0227,169,2,0.0118,138,1,0.0072,31,1,0.0323
+Trenčiansky,Púchov,Zubák,652,22,0.0337,608,17,0.028,191,3,0.0157,188,3,0.016,3,0,0
+Trenčiansky,Trenčín,Adamovské Kochanovce,640,0,0,645,4,0.0062,,,,,,,,,
+Trenčiansky,Trenčín,Bobot,575,12,0.0209,428,2,0.0047,,,,,,,,,
+Trenčiansky,Trenčín,Dolná Poruba,654,4,0.0061,569,7,0.0123,198,3,0.0152,155,3,0.0194,43,0,0
+Trenčiansky,Trenčín,Dolná Súča,2025,30,0.0148,2455,7,0.0029,,,,,,,,,
+Trenčiansky,Trenčín,Drietoma,1468,12,0.0082,1542,16,0.0104,458,12,0.0262,312,0,0,146,12,0.0822
+Trenčiansky,Trenčín,Dubodiel,730,7,0.0096,731,4,0.0055,,,,,,,,,
+Trenčiansky,Trenčín,Horná Súča,2108,86,0.0408,1933,11,0.0057,,,,,,,,,
+Trenčiansky,Trenčín,Horňany,264,4,0.0152,232,4,0.0172,103,2,0.0194,76,0,0,27,2,0.0741
+Trenčiansky,Trenčín,Horné Srnie,1769,17,0.0096,1746,12,0.0069,,,,,,,,,
+Trenčiansky,Trenčín,Hrabovka,439,11,0.0251,351,0,0,,,,,,,,,
+Trenčiansky,Trenčín,Chocholná - Velčice,1314,12,0.0091,1243,16,0.0129,661,30,0.0454,430,3,0.007,231,27,0.1169
+Trenčiansky,Trenčín,Ivanovce,608,5,0.0082,614,1,0.0016,,,,,,,,,
+Trenčiansky,Trenčín,Kostolná - Záriečie,521,3,0.0058,494,1,0.002,,,,,,,,,
+Trenčiansky,Trenčín,Krivosúd - Bodovka,217,0,0,232,0,0,,,,,,,,,
+Trenčiansky,Trenčín,Melčice - Lieskové,1325,10,0.0075,1166,0,0,,,,,,,,,
+Trenčiansky,Trenčín,Mníchova Lehota,930,16,0.0172,911,10,0.011,428,7,0.0164,266,0,0,162,7,0.0432
+Trenčiansky,Trenčín,Motešice,636,15,0.0236,605,2,0.0033,,,,,,,,,
+Trenčiansky,Trenčín,Nemšová,4293,41,0.0096,4166,28,0.0067,,,,,,,,,
+Trenčiansky,Trenčín,Neporadza,570,14,0.0246,551,9,0.0163,223,3,0.0135,193,0,0,30,3,0.1
+Trenčiansky,Trenčín,Omšenie,1052,23,0.0219,1052,3,0.0029,,,,,,,,,
+Trenčiansky,Trenčín,Opatovce,390,2,0.0051,346,1,0.0029,,,,,,,,,
+Trenčiansky,Trenčín,Petrova Lehota,133,1,0.0075,114,0,0,,,,,,,,,
+Trenčiansky,Trenčín,Selec,816,14,0.0172,676,5,0.0074,,,,,,,,,
+Trenčiansky,Trenčín,Skalka nad Váhom,944,7,0.0074,749,2,0.0027,,,,,,,,,
+Trenčiansky,Trenčín,Soblahov,1848,20,0.0108,1699,10,0.0059,,,,,,,,,
+Trenčiansky,Trenčín,Svinná,1045,24,0.023,1053,8,0.0076,,,,,,,,,
+Trenčiansky,Trenčín,Štvrtok,377,1,0.0027,369,2,0.0054,,,,,,,,,
+Trenčiansky,Trenčín,Trenčianska Teplá,2594,28,0.0108,2512,13,0.0052,,,,,,,,,
+Trenčiansky,Trenčín,Trenčianska Turná,2077,43,0.0207,2142,9,0.0042,,,,,,,,,
+Trenčiansky,Trenčín,Trenčianske Jastrabie,831,8,0.0096,876,4,0.0046,,,,,,,,,
+Trenčiansky,Trenčín,Trenčianske Mitice,570,9,0.0158,563,6,0.0107,177,1,0.0056,137,1,0.0073,40,0,0
+Trenčiansky,Trenčín,Trenčianske Stankovce,2293,15,0.0065,2341,11,0.0047,,,,,,,,,
+Trenčiansky,Trenčín,Trenčianske Teplice,2545,38,0.0149,2702,14,0.0052,,,,,,,,,
+Trenčiansky,Trenčín,Trenčín,32865,332,0.0101,32990,202,0.0061,,,,,,,,,
+Trenčiansky,Trenčín,Veľká Hradná,548,16,0.0292,483,3,0.0062,,,,,,,,,
+Trenčiansky,Trenčín,Veľké Bierovce,540,4,0.0074,501,1,0.002,,,,,,,,,
+Trenčiansky,Trenčín,Zamarovce,870,10,0.0115,764,6,0.0079,,,,,,,,,
+Trnavský,Dunajská Streda,Báč,783,5,0.0064,671,3,0.0045,,,,,,,,,
+Trnavský,Dunajská Streda,Baka,556,15,0.027,835,11,0.0132,533,15,0.0281,351,0,0,182,15,0.0824
+Trnavský,Dunajská Streda,Baloň,620,6,0.0097,659,2,0.003,,,,,,,,,
+Trnavský,Dunajská Streda,Bellova Ves,221,0,0,309,0,0,,,,,,,,,
+Trnavský,Dunajská Streda,Blahová,558,1,0.0018,485,2,0.0041,,,,,,,,,
+Trnavský,Dunajská Streda,Blatná na Ostrove,830,5,0.006,982,5,0.0051,,,,,,,,,
+Trnavský,Dunajská Streda,Bodíky,715,0,0,632,1,0.0016,,,,,,,,,
+Trnavský,Dunajská Streda,Boheľov,221,2,0.009,251,1,0.004,,,,,,,,,
+Trnavský,Dunajská Streda,Čakany,777,8,0.0103,1208,0,0,,,,,,,,,
+Trnavský,Dunajská Streda,Čenkovce,891,0,0,1344,6,0.0045,,,,,,,,,
+Trnavský,Dunajská Streda,Čiližská Radvaň,718,4,0.0056,827,3,0.0036,,,,,,,,,
+Trnavský,Dunajská Streda,Dobrohošť,600,2,0.0033,776,1,0.0013,,,,,,,,,
+Trnavský,Dunajská Streda,Dolný Bar,799,6,0.0075,873,3,0.0034,,,,,,,,,
+Trnavský,Dunajská Streda,Dolný Štál,1520,31,0.0204,1600,9,0.0056,,,,,,,,,
+Trnavský,Dunajská Streda,Dunajská Streda,12293,115,0.0094,14013,102,0.0073,,,,,,,,,
+Trnavský,Dunajská Streda,Dunajský Klátov,776,5,0.0064,1354,4,0.003,,,,,,,,,
+Trnavský,Dunajská Streda,Gabčíkovo,3479,57,0.0164,3839,12,0.0031,,,,,,,,,
+Trnavský,Dunajská Streda,Holice,1528,7,0.0046,1697,4,0.0024,,,,,,,,,
+Trnavský,Dunajská Streda,Horná Potôň,1766,14,0.0079,1842,8,0.0043,,,,,,,,,
+Trnavský,Dunajská Streda,Horné Mýto,615,3,0.0049,902,2,0.0022,,,,,,,,,
+Trnavský,Dunajská Streda,Horný Bar,1158,15,0.013,1104,1,0.0009,,,,,,,,,
+Trnavský,Dunajská Streda,Hubice,531,2,0.0038,487,10,0.0205,354,8,0.0226,189,2,0.0106,165,6,0.0364
+Trnavský,Dunajská Streda,Hviezdoslavov,2222,12,0.0054,3836,18,0.0047,,,,,,,,,
+Trnavský,Dunajská Streda,Jahodná,984,1,0.001,1915,4,0.0021,,,,,,,,,
+Trnavský,Dunajská Streda,Janíky,793,7,0.0088,1290,5,0.0039,,,,,,,,,
+Trnavský,Dunajská Streda,Jurová,339,5,0.0147,604,3,0.005,,,,,,,,,
+Trnavský,Dunajská Streda,Kľúčovec,236,1,0.0042,534,2,0.0037,,,,,,,,,
+Trnavský,Dunajská Streda,Kostolné Kračany,978,18,0.0184,1045,18,0.0172,495,18,0.0364,320,10,0.0313,175,8,0.0457
+Trnavský,Dunajská Streda,Kráľovičove Kračany,1109,8,0.0072,1173,11,0.0094,,,,,,,,,
+Trnavský,Dunajská Streda,Kútniky,999,13,0.013,1031,3,0.0029,,,,,,,,,
+Trnavský,Dunajská Streda,Kvetoslavov,1442,4,0.0028,2436,7,0.0029,,,,,,,,,
+Trnavský,Dunajská Streda,Kyselica,113,0,0,295,1,0.0034,,,,,,,,,
+Trnavský,Dunajská Streda,Lehnice,1713,10,0.0058,2110,13,0.0062,,,,,,,,,
+Trnavský,Dunajská Streda,Lúč na Ostrove,1105,7,0.0063,709,2,0.0028,,,,,,,,,
+Trnavský,Dunajská Streda,Macov,353,1,0.0028,480,2,0.0042,,,,,,,,,
+Trnavský,Dunajská Streda,Mad,302,2,0.0066,281,2,0.0071,,,,,,,,,
+Trnavský,Dunajská Streda,Malé Dvorníky,1174,17,0.0145,1225,8,0.0065,,,,,,,,,
+Trnavský,Dunajská Streda,Medveďov,330,4,0.0121,389,1,0.0026,,,,,,,,,
+Trnavský,Dunajská Streda,Mierovo,255,1,0.0039,445,1,0.0022,,,,,,,,,
+Trnavský,Dunajská Streda,Michal na Ostrove,858,9,0.0105,889,1,0.0011,,,,,,,,,
+Trnavský,Dunajská Streda,Ňárad,682,4,0.0059,641,4,0.0062,,,,,,,,,
+Trnavský,Dunajská Streda,Nový Život,1776,4,0.0023,2516,5,0.002,,,,,,,,,
+Trnavský,Dunajská Streda,Ohrady,1052,13,0.0124,1079,7,0.0065,,,,,,,,,
+Trnavský,Dunajská Streda,Okoč,2481,43,0.0173,3534,29,0.0082,,,,,,,,,
+Trnavský,Dunajská Streda,Oľdza,734,4,0.0054,1163,4,0.0034,,,,,,,,,
+Trnavský,Dunajská Streda,Orechová Potôň,1671,14,0.0084,1608,4,0.0025,,,,,,,,,
+Trnavský,Dunajská Streda,Padáň,759,12,0.0158,740,1,0.0014,,,,,,,,,
+Trnavský,Dunajská Streda,Pataš,566,9,0.0159,701,4,0.0057,,,,,,,,,
+Trnavský,Dunajská Streda,Potônske Lúky,423,2,0.0047,382,1,0.0026,,,,,,,,,
+Trnavský,Dunajská Streda,Povoda,1147,13,0.0113,1132,11,0.0097,,,,,,,,,
+Trnavský,Dunajská Streda,Rohovce,908,5,0.0055,1100,7,0.0064,,,,,,,,,
+Trnavský,Dunajská Streda,Sap,361,7,0.0194,411,4,0.0097,,,,,,,,,
+Trnavský,Dunajská Streda,Šamorín,7942,30,0.0038,12773,49,0.0038,,,,,,,,,
+Trnavský,Dunajská Streda,Štvrtok na Ostrove,1139,7,0.0061,1689,5,0.003,,,,,,,,,
+Trnavský,Dunajská Streda,Topoľníky,2096,24,0.0115,2878,19,0.0066,,,,,,,,,
+Trnavský,Dunajská Streda,Trhová Hradská,1746,6,0.0034,2085,1,0.0005,,,,,,,,,
+Trnavský,Dunajská Streda,Trnávka,398,6,0.0151,475,2,0.0042,,,,,,,,,
+Trnavský,Dunajská Streda,Trstená na Ostrove,864,5,0.0058,407,4,0.0098,,,,,,,,,
+Trnavský,Dunajská Streda,Veľká Paka,888,15,0.0169,892,2,0.0022,,,,,,,,,
+Trnavský,Dunajská Streda,Veľké Blahovo,977,6,0.0061,1066,5,0.0047,,,,,,,,,
+Trnavský,Dunajská Streda,Veľké Dvorníky,893,7,0.0078,1159,4,0.0035,,,,,,,,,
+Trnavský,Dunajská Streda,Veľký Meder,5305,81,0.0153,7709,63,0.0082,,,,,,,,,
+Trnavský,Dunajská Streda,Vieska,246,1,0.0041,300,0,0,,,,,,,,,
+Trnavský,Dunajská Streda,Vojka nad Dunajom,362,0,0,699,7,0.01,210,6,0.0286,112,2,0.0179,98,4,0.0408
+Trnavský,Dunajská Streda,Vrakúň,1491,61,0.0409,1555,31,0.0199,903,25,0.0277,672,9,0.0134,231,16,0.0693
+Trnavský,Dunajská Streda,Vydrany,981,20,0.0204,1216,2,0.0016,,,,,,,,,
+Trnavský,Dunajská Streda,Zlaté Klasy,1942,18,0.0093,2796,10,0.0036,,,,,,,,,
+Trnavský,Galanta,Abrahám,960,5,0.0052,,,,,,,,,,,,
+Trnavský,Galanta,Čierna Voda,948,8,0.0084,,,,,,,,,,,,
+Trnavský,Galanta,Čierny Brod,1200,6,0.005,,,,,,,,,,,,
+Trnavský,Galanta,Dolná Streda,927,1,0.0011,,,,,,,,,,,,
+Trnavský,Galanta,Dolné Saliby,1721,4,0.0023,,,,,,,,,,,,
+Trnavský,Galanta,Dolný Chotár,209,0,0,,,,,,,,,,,,
+Trnavský,Galanta,Galanta,10202,32,0.0031,,,,,,,,,,,,
+Trnavský,Galanta,Gáň,710,1,0.0014,,,,,,,,,,,,
+Trnavský,Galanta,Horné Saliby,1663,10,0.006,,,,,,,,,,,,
+Trnavský,Galanta,Hoste,305,0,0,,,,,,,,,,,,
+Trnavský,Galanta,Jánovce,449,1,0.0022,,,,,,,,,,,,
+Trnavský,Galanta,Jelka,3368,5,0.0015,,,,,,,,,,,,
+Trnavský,Galanta,Kajal,989,11,0.0111,,,,283,16,0.0565,131,1,0.0076,152,15,0.0987
+Trnavský,Galanta,Košúty,1145,6,0.0052,,,,,,,,,,,,
+Trnavský,Galanta,Kráľov Brod,841,2,0.0024,,,,,,,,,,,,
+Trnavský,Galanta,Malá Mača,565,1,0.0018,,,,,,,,,,,,
+Trnavský,Galanta,Matúškovo,1670,5,0.003,,,,,,,,,,,,
+Trnavský,Galanta,Mostová,860,1,0.0012,,,,,,,,,,,,
+Trnavský,Galanta,Pata,2062,6,0.0029,,,,,,,,,,,,
+Trnavský,Galanta,Pusté Sady,535,1,0.0019,,,,,,,,,,,,
+Trnavský,Galanta,Pusté Úľany,1013,9,0.0089,,,,,,,,,,,,
+Trnavský,Galanta,Sereď,9873,50,0.0051,,,,,,,,,,,,
+Trnavský,Galanta,Sládkovičovo,3954,17,0.0043,,,,,,,,,,,,
+Trnavský,Galanta,Šalgočka,216,2,0.0093,,,,,,,,,,,,
+Trnavský,Galanta,Šintava,1230,3,0.0024,,,,,,,,,,,,
+Trnavský,Galanta,Šoporňa,2605,17,0.0065,,,,,,,,,,,,
+Trnavský,Galanta,Tomášikovo,1252,8,0.0064,,,,,,,,,,,,
+Trnavský,Galanta,Topoľnica,704,7,0.0099,,,,,,,,,,,,
+Trnavský,Galanta,Trstice,2682,43,0.016,,,,591,11,0.0186,473,6,0.0127,118,5,0.0424
+Trnavský,Galanta,Váhovce,1399,13,0.0093,,,,,,,,,,,,
+Trnavský,Galanta,Veľká Mača,1732,4,0.0023,,,,,,,,,,,,
+Trnavský,Galanta,Veľké Úľany,3444,10,0.0029,,,,,,,,,,,,
+Trnavský,Galanta,Veľký Grob,1064,5,0.0047,,,,,,,,,,,,
+Trnavský,Galanta,Vinohrady nad Váhom,992,9,0.0091,,,,,,,,,,,,
+Trnavský,Galanta,Vozokany,814,0,0,,,,,,,,,,,,
+Trnavský,Galanta,Zemianske Sady,538,0,0,,,,,,,,,,,,
+Trnavský,Hlohovec,Bojničky,1226,4,0.0033,,,,,,,,,,,,
+Trnavský,Hlohovec,Červeník,988,4,0.004,,,,,,,,,,,,
+Trnavský,Hlohovec,Dolné Trhovište,495,3,0.0061,,,,,,,,,,,,
+Trnavský,Hlohovec,Dolné Zelenice,485,0,0,,,,,,,,,,,,
+Trnavský,Hlohovec,Dvorníky,1208,3,0.0025,,,,,,,,,,,,
+Trnavský,Hlohovec,Hlohovec,12005,72,0.006,,,,,,,,,,,,
+Trnavský,Hlohovec,Horné Otrokovce,703,4,0.0057,,,,,,,,,,,,
+Trnavský,Hlohovec,Horné Trhovište,667,2,0.003,,,,,,,,,,,,
+Trnavský,Hlohovec,Horné Zelenice,527,3,0.0057,,,,,,,,,,,,
+Trnavský,Hlohovec,Kľačany,701,5,0.0071,,,,,,,,,,,,
+Trnavský,Hlohovec,Koplotovce,988,8,0.0081,,,,,,,,,,,,
+Trnavský,Hlohovec,Leopoldov,2626,12,0.0046,,,,,,,,,,,,
+Trnavský,Hlohovec,Madunice,1710,14,0.0082,,,,,,,,,,,,
+Trnavský,Hlohovec,Merašice,528,15,0.0284,,,,69,0,0,60,0,0,9,0,0
+Trnavský,Hlohovec,Pastuchov,649,9,0.0139,,,,209,7,0.0335,129,2,0.0155,80,5,0.0625
+Trnavský,Hlohovec,Sasinkovo,681,3,0.0044,,,,,,,,,,,,
+Trnavský,Hlohovec,Siladice,593,4,0.0067,,,,,,,,,,,,
+Trnavský,Hlohovec,Trakovice,1085,4,0.0037,,,,,,,,,,,,
+Trnavský,Hlohovec,Žlkovce,610,2,0.0033,,,,,,,,,,,,
+Trnavský,Piešťany,Banka,1501,7,0.0047,,,,,,,,,,,,
+Trnavský,Piešťany,Bašovce,532,3,0.0056,,,,,,,,,,,,
+Trnavský,Piešťany,Borovce,789,8,0.0101,,,,302,7,0.0232,120,0,0,182,7,0.0385
+Trnavský,Piešťany,Dolný Lopašov,561,1,0.0018,,,,,,,,,,,,
+Trnavský,Piešťany,Drahovce,1699,5,0.0029,,,,,,,,,,,,
+Trnavský,Piešťany,Dubovany,885,8,0.009,,,,,,,,,,,,
+Trnavský,Piešťany,Ducové,190,1,0.0053,,,,,,,,,,,,
+Trnavský,Piešťany,Hubina,522,3,0.0057,,,,,,,,,,,,
+Trnavský,Piešťany,Chtelnica,1876,17,0.0091,,,,,,,,,,,,
+Trnavský,Piešťany,Kočín - Lančár,577,0,0,,,,,,,,,,,,
+Trnavský,Piešťany,Krakovany,954,2,0.0021,,,,,,,,,,,,
+Trnavský,Piešťany,Moravany nad Váhom,1414,3,0.0021,,,,,,,,,,,,
+Trnavský,Piešťany,Nižná,513,1,0.0019,,,,,,,,,,,,
+Trnavský,Piešťany,Ostrov,729,3,0.0041,,,,,,,,,,,,
+Trnavský,Piešťany,Pečeňady,554,5,0.009,,,,,,,,,,,,
+Trnavský,Piešťany,Piešťany,15216,79,0.0052,,,,,,,,,,,,
+Trnavský,Piešťany,Prašník,770,0,0,,,,,,,,,,,,
+Trnavský,Piešťany,Rakovice,694,3,0.0043,,,,,,,,,,,,
+Trnavský,Piešťany,Ratnovce,777,5,0.0064,,,,,,,,,,,,
+Trnavský,Piešťany,Sokolovce,852,7,0.0082,,,,,,,,,,,,
+Trnavský,Piešťany,Šípkové,201,1,0.005,,,,,,,,,,,,
+Trnavský,Piešťany,Šterusy,269,0,0,,,,,,,,,,,,
+Trnavský,Piešťany,Trebatice,988,7,0.0071,,,,,,,,,,,,
+Trnavský,Piešťany,Veľké Kostoľany,1388,1,0.0007,,,,,,,,,,,,
+Trnavský,Piešťany,Veľké Orvište,1086,3,0.0028,,,,,,,,,,,,
+Trnavský,Piešťany,Veselé,802,4,0.005,,,,,,,,,,,,
+Trnavský,Piešťany,Vrbové,2741,8,0.0029,,,,,,,,,,,,
+Trnavský,Senica,Bílkove Humence,202,1,0.005,266,0,0,,,,,,,,,
+Trnavský,Senica,Borský Mikuláš,2922,18,0.0062,2958,5,0.0017,,,,,,,,,
+Trnavský,Senica,Borský Svätý Jur,1166,11,0.0094,1294,2,0.0015,,,,,,,,,
+Trnavský,Senica,Cerová,698,4,0.0057,863,8,0.0093,,,,,,,,,
+Trnavský,Senica,Čáry,909,6,0.0066,994,1,0.001,,,,,,,,,
+Trnavský,Senica,Častkov,323,4,0.0124,545,3,0.0055,,,,,,,,,
+Trnavský,Senica,Dojč,469,2,0.0043,766,3,0.0039,,,,,,,,,
+Trnavský,Senica,Hlboké,742,10,0.0135,765,4,0.0052,,,,,,,,,
+Trnavský,Senica,Hradište pod Vrátnom,553,3,0.0054,605,1,0.0017,,,,,,,,,
+Trnavský,Senica,Jablonica,1609,0,0,2316,7,0.003,,,,,,,,,
+Trnavský,Senica,Koválov,622,8,0.0129,570,2,0.0035,,,,,,,,,
+Trnavský,Senica,Kuklov,713,11,0.0154,699,4,0.0057,,,,,,,,,
+Trnavský,Senica,Kúty,2048,25,0.0122,2709,10,0.0037,,,,,,,,,
+Trnavský,Senica,Lakšárska Nová Ves,867,1,0.0012,1167,3,0.0026,,,,,,,,,
+Trnavský,Senica,Moravský Svätý Ján,2008,19,0.0095,2699,15,0.0056,,,,,,,,,
+Trnavský,Senica,Osuské,496,0,0,543,5,0.0092,,,,,,,,,
+Trnavský,Senica,Plavecký Peter,546,4,0.0073,921,3,0.0033,,,,,,,,,
+Trnavský,Senica,Podbranč,629,7,0.0111,517,0,0,,,,,,,,,
+Trnavský,Senica,Prietrž,797,16,0.0201,712,3,0.0042,,,,,,,,,
+Trnavský,Senica,Prievaly,810,5,0.0062,1104,3,0.0027,,,,,,,,,
+Trnavský,Senica,Rohov,547,6,0.011,313,2,0.0064,,,,,,,,,
+Trnavský,Senica,Rovensko,470,2,0.0043,312,0,0,,,,,,,,,
+Trnavský,Senica,Rybky,304,4,0.0132,280,3,0.0107,94,0,0,85,0,0,9,0,0
+Trnavský,Senica,Sekule,1719,16,0.0093,1785,5,0.0028,,,,,,,,,
+Trnavský,Senica,Senica,11490,127,0.0111,12794,71,0.0055,,,,,,,,,
+Trnavský,Senica,Smolinské,702,12,0.0171,765,4,0.0052,,,,,,,,,
+Trnavský,Senica,Smrdáky,610,7,0.0115,498,2,0.004,,,,,,,,,
+Trnavský,Senica,Sobotište,878,5,0.0057,1057,1,0.0009,,,,,,,,,
+Trnavský,Senica,Šajdíkove Humence,858,8,0.0093,885,6,0.0068,,,,,,,,,
+Trnavský,Senica,Šaštín - Stráže,2586,29,0.0112,3032,14,0.0046,,,,,,,,,
+Trnavský,Senica,Štefanov,1382,13,0.0094,1266,4,0.0032,,,,,,,,,
+Trnavský,Skalica,Brodské,1579,22,0.0139,1696,9,0.0053,,,,,,,,,
+Trnavský,Skalica,Dubovce,655,11,0.0168,505,2,0.004,,,,,,,,,
+Trnavský,Skalica,Gbely,3091,17,0.0055,3274,15,0.0046,,,,,,,,,
+Trnavský,Skalica,Holíč,5034,72,0.0143,6243,24,0.0038,,,,,,,,,
+Trnavský,Skalica,Chropov,429,4,0.0093,384,1,0.0026,,,,,,,,,
+Trnavský,Skalica,Kátov,603,11,0.0182,576,2,0.0035,,,,,,,,,
+Trnavský,Skalica,Kopčany,1877,29,0.0155,1889,18,0.0095,,,,,,,,,
+Trnavský,Skalica,Koválovec,118,2,0.0169,147,1,0.0068,,,,,,,,,
+Trnavský,Skalica,Letničie,489,0,0,423,0,0,,,,,,,,,
+Trnavský,Skalica,Lopašov,195,4,0.0205,203,3,0.0148,157,8,0.051,124,0,0,33,8,0.2424
+Trnavský,Skalica,Mokrý Háj,544,7,0.0129,512,2,0.0039,,,,,,,,,
+Trnavský,Skalica,Oreské,414,6,0.0145,347,3,0.0086,,,,,,,,,
+Trnavský,Skalica,Petrova Ves,827,16,0.0193,830,4,0.0048,,,,,,,,,
+Trnavský,Skalica,Popudinské Močidľany,630,9,0.0143,645,1,0.0016,,,,,,,,,
+Trnavský,Skalica,Prietržka,686,10,0.0146,533,2,0.0038,,,,,,,,,
+Trnavský,Skalica,Radimov,843,5,0.0059,665,1,0.0015,,,,,,,,,
+Trnavský,Skalica,Radošovce,1336,13,0.0097,1311,8,0.0061,,,,,,,,,
+Trnavský,Skalica,Skalica,8333,108,0.013,9399,54,0.0057,,,,,,,,,
+Trnavský,Skalica,Trnovec,181,0,0,291,1,0.0034,,,,,,,,,
+Trnavský,Skalica,Unín,696,10,0.0144,696,9,0.0129,286,3,0.0105,237,3,0.0127,49,0,0
+Trnavský,Skalica,Vrádište,663,12,0.0181,631,8,0.0127,269,12,0.0446,149,3,0.0201,120,9,0.075
+Trnavský,Trnava,Biely Kostol,1721,15,0.0087,,,,,,,,,,,,
+Trnavský,Trnava,Bíňovce,594,1,0.0017,,,,,,,,,,,,
+Trnavský,Trnava,Bohdanovce nad Trnavou,943,4,0.0042,,,,,,,,,,,,
+Trnavský,Trnava,Boleráz,1698,17,0.01,,,,475,4,0.0084,389,1,0.0026,86,3,0.0349
+Trnavský,Trnava,Borová,335,3,0.009,,,,,,,,,,,,
+Trnavský,Trnava,Brestovany,1460,8,0.0055,,,,,,,,,,,,
+Trnavský,Trnava,Bučany,1980,5,0.0025,,,,,,,,,,,,
+Trnavský,Trnava,Buková,646,1,0.0015,,,,,,,,,,,,
+Trnavský,Trnava,Cífer,3595,10,0.0028,,,,,,,,,,,,
+Trnavský,Trnava,Dechtice,1159,4,0.0035,,,,,,,,,,,,
+Trnavský,Trnava,Dlhá,424,8,0.0189,,,,76,1,0.0132,64,0,0,12,1,0.0833
+Trnavský,Trnava,Dobrá Voda,659,3,0.0046,,,,,,,,,,,,
+Trnavský,Trnava,Dolná Krupá,1865,14,0.0075,,,,,,,,,,,,
+Trnavský,Trnava,Dolné Dubové,696,2,0.0029,,,,,,,,,,,,
+Trnavský,Trnava,Dolné Lovčice,856,8,0.0093,,,,,,,,,,,,
+Trnavský,Trnava,Dolné Orešany,783,2,0.0026,,,,,,,,,,,,
+Trnavský,Trnava,Horná Krupá,565,2,0.0035,,,,,,,,,,,,
+Trnavský,Trnava,Horné Orešany,1470,3,0.002,,,,,,,,,,,,
+Trnavský,Trnava,Hrnčiarovce nad Parnou,1558,10,0.0064,,,,,,,,,,,,
+Trnavský,Trnava,Jaslovské Bohunice,1603,9,0.0056,,,,,,,,,,,,
+Trnavský,Trnava,Kátlovce,935,2,0.0021,,,,,,,,,,,,
+Trnavský,Trnava,Košolná,533,9,0.0169,,,,209,8,0.0383,124,2,0.0161,85,6,0.0706
+Trnavský,Trnava,Križovany nad Dudváhom,1468,20,0.0136,,,,493,10,0.0203,339,0,0,154,10,0.0649
+Trnavský,Trnava,Lošonec,527,3,0.0057,,,,,,,,,,,,
+Trnavský,Trnava,Majcichov,1315,4,0.003,,,,,,,,,,,,
+Trnavský,Trnava,Malženice,972,9,0.0093,,,,,,,,,,,,
+Trnavský,Trnava,Naháč,266,3,0.0113,,,,143,1,0.007,113,1,0.0088,30,0,0
+Trnavský,Trnava,Opoj,823,6,0.0073,,,,,,,,,,,,
+Trnavský,Trnava,Pavlice,569,5,0.0088,,,,,,,,,,,,
+Trnavský,Trnava,Ružindol,1089,9,0.0083,,,,,,,,,,,,
+Trnavský,Trnava,Slovenská Nová Ves,265,0,0,,,,,,,,,,,,
+Trnavský,Trnava,Smolenice,3267,8,0.0024,,,,,,,,,,,,
+Trnavský,Trnava,Suchá nad Parnou,2191,11,0.005,,,,,,,,,,,,
+Trnavský,Trnava,Šelpice,807,2,0.0025,,,,,,,,,,,,
+Trnavský,Trnava,Špačince,2362,31,0.0131,,,,591,24,0.0406,355,7,0.0197,236,17,0.072
+Trnavský,Trnava,Šúrovce,1543,6,0.0039,,,,,,,,,,,,
+Trnavský,Trnava,Trnava,35474,224,0.0063,,,,,,,,,,,,
+Trnavský,Trnava,Trstín,838,13,0.0155,,,,268,3,0.0112,187,0,0,81,3,0.037
+Trnavský,Trnava,Vlčkovce,1137,9,0.0079,,,,,,,,,,,,
+Trnavský,Trnava,Voderady,1098,4,0.0036,,,,,,,,,,,,
+Trnavský,Trnava,Zavar,1574,14,0.0089,,,,,,,,,,,,
+Trnavský,Trnava,Zeleneč,1744,7,0.004,,,,,,,,,,,,
+Trnavský,Trnava,Zvončín,813,4,0.0049,,,,,,,,,,,,
+Žilinský,Bytča,Bytča,6932,114,0.0164,7009,78,0.0111,2215,62,0.028,1753,32,0.0183,462,30,0.0649
+Žilinský,Bytča,Hlboké nad Váhom,1094,18,0.0165,870,10,0.0115,203,6,0.0296,148,0,0,55,6,0.1091
+Žilinský,Bytča,Hvozdnica,757,6,0.0079,775,4,0.0052,,,,,,,,,
+Žilinský,Bytča,Jablonové,693,11,0.0159,712,6,0.0084,,,,,,,,,
+Žilinský,Bytča,Kolárovice,1065,13,0.0122,1136,12,0.0106,228,6,0.0263,186,2,0.0108,42,4,0.0952
+Žilinský,Bytča,Kotešová,1613,21,0.013,1619,5,0.0031,,,,,,,,,
+Žilinský,Bytča,Maršová - Rašov,551,13,0.0236,563,4,0.0071,,,,,,,,,
+Žilinský,Bytča,Petrovice,1064,26,0.0244,1054,9,0.0085,,,,,,,,,
+Žilinský,Bytča,Predmier,1334,30,0.0225,1116,4,0.0036,,,,,,,,,
+Žilinský,Bytča,Súľov - Hradná,753,9,0.012,800,5,0.0063,,,,,,,,,
+Žilinský,Bytča,Štiavnik,2793,27,0.0097,2743,12,0.0044,,,,,,,,,
+Žilinský,Bytča,Veľké Rovné,2410,23,0.0095,2534,15,0.0059,,,,,,,,,
+Žilinský,Čadca,Čadca,11703,319,0.0273,12492,136,0.0109,3144,52,0.0165,2709,37,0.0137,435,15,0.0345
+Žilinský,Čadca,Čierne,2523,76,0.0301,2488,21,0.0084,,,,,,,,,
+Žilinský,Čadca,Dlhá nad Kysucou,707,29,0.041,622,4,0.0064,,,,,,,,,
+Žilinský,Čadca,Dunajov,839,13,0.0155,748,3,0.004,,,,,,,,,
+Žilinský,Čadca,Klokočov,1532,69,0.045,1418,15,0.0106,363,12,0.0331,294,10,0.034,69,2,0.029
+Žilinský,Čadca,Klubina,572,18,0.0315,511,5,0.0098,,,,,,,,,
+Žilinský,Čadca,Korňa,1283,60,0.0468,1119,7,0.0063,,,,,,,,,
+Žilinský,Čadca,Krásno nad Kysucou,4542,114,0.0251,4471,32,0.0072,,,,,,,,,
+Žilinský,Čadca,Makov,1290,31,0.024,1255,11,0.0088,,,,,,,,,
+Žilinský,Čadca,Nová Bystrica,2117,70,0.0331,1594,27,0.0169,338,5,0.0148,293,4,0.0137,45,1,0.0222
+Žilinský,Čadca,Olešná,1034,29,0.028,949,2,0.0021,,,,,,,,,
+Žilinský,Čadca,Oščadnica,3676,98,0.0267,3638,39,0.0107,785,15,0.0191,688,11,0.016,97,4,0.0412
+Žilinský,Čadca,Podvysoká,1072,24,0.0224,1050,12,0.0114,344,17,0.0494,217,6,0.0276,127,11,0.0866
+Žilinský,Čadca,Radôstka,645,15,0.0233,591,1,0.0017,,,,,,,,,
+Žilinský,Čadca,Raková,3384,128,0.0378,3180,26,0.0082,,,,,,,,,
+Žilinský,Čadca,Skalité,3134,106,0.0338,2945,33,0.0112,673,7,0.0104,595,5,0.0084,78,2,0.0256
+Žilinský,Čadca,Stará Bystrica,1767,78,0.0441,1666,11,0.0066,,,,,,,,,
+Žilinský,Čadca,Staškov,2055,48,0.0234,1953,26,0.0133,567,6,0.0106,451,5,0.0111,116,1,0.0086
+Žilinský,Čadca,Svrčinovec,1780,41,0.023,1799,26,0.0145,504,6,0.0119,401,4,0.01,103,2,0.0194
+Žilinský,Čadca,Turzovka,3889,190,0.0489,3738,37,0.0099,,,,,,,,,
+Žilinský,Čadca,Vysoká nad Kysucou,1623,51,0.0314,1561,12,0.0077,,,,,,,,,
+Žilinský,Čadca,Zákopčie,1260,36,0.0286,1201,6,0.005,,,,,,,,,
+Žilinský,Čadca,Zborov nad Bystricou,1480,48,0.0324,1315,14,0.0106,306,5,0.0163,231,3,0.013,75,2,0.0267
+Žilinský,Dolný Kubín,Bziny,380,3,0.0079,386,4,0.0104,139,2,0.0144,83,0,0,56,2,0.0357
+Žilinský,Dolný Kubín,Dlhá nad Oravou,755,14,0.0185,779,7,0.009,,,,,,,,,
+Žilinský,Dolný Kubín,Dolný Kubín,10430,155,0.0149,10262,57,0.0056,,,,,,,,,
+Žilinský,Dolný Kubín,Horná Lehota,451,8,0.0177,436,5,0.0115,129,1,0.0078,115,0,0,14,1,0.0714
+Žilinský,Dolný Kubín,Chlebnice,762,20,0.0262,821,7,0.0085,,,,,,,,,
+Žilinský,Dolný Kubín,Istebné,820,3,0.0037,889,4,0.0045,,,,,,,,,
+Žilinský,Dolný Kubín,Jasenová,412,4,0.0097,348,0,0,,,,,,,,,
+Žilinský,Dolný Kubín,Kraľovany,474,14,0.0295,440,0,0,,,,,,,,,
+Žilinský,Dolný Kubín,Krivá,576,5,0.0087,584,2,0.0034,,,,,,,,,
+Žilinský,Dolný Kubín,Leštiny,320,2,0.0063,327,3,0.0092,,,,,,,,,
+Žilinský,Dolný Kubín,Malatiná,487,15,0.0308,508,2,0.0039,,,,,,,,,
+Žilinský,Dolný Kubín,Medzibrodie n +Oravou,410,5,0.0122,430,0,0,,,,,,,,,
+Žilinský,Dolný Kubín,Oravská  Poruba,650,5,0.0077,727,0,0,,,,,,,,,
+Žilinský,Dolný Kubín,Oravský Podzámok,990,18,0.0182,974,5,0.0051,,,,,,,,,
+Žilinský,Dolný Kubín,Osádka,214,2,0.0093,170,0,0,,,,,,,,,
+Žilinský,Dolný Kubín,Párnica,628,9,0.0143,661,6,0.0091,,,,,,,,,
+Žilinský,Dolný Kubín,Pokrývač,191,5,0.0262,159,1,0.0063,,,,,,,,,
+Žilinský,Dolný Kubín,Pribiš,351,1,0.0028,337,1,0.003,,,,,,,,,
+Žilinský,Dolný Kubín,Pucov,477,3,0.0063,520,1,0.0019,,,,,,,,,
+Žilinský,Dolný Kubín,Sedliacka Dubová,443,4,0.009,396,3,0.0076,,,,,,,,,
+Žilinský,Dolný Kubín,Veličná,970,4,0.0041,986,5,0.0051,,,,,,,,,
+Žilinský,Dolný Kubín,Vyšný Kubín,399,5,0.0125,398,2,0.005,,,,,,,,,
+Žilinský,Dolný Kubín,Zaškov,942,16,0.017,980,6,0.0061,,,,,,,,,
+Žilinský,Dolný Kubín,Zázrivá,1497,25,0.0167,1652,17,0.0103,632,16,0.0253,517,4,0.0077,115,12,0.1043
+Žilinský,Kysucké Nové Mesto,Dolný Vadičov,312,9,0.0288,451,0,0,,,,,,,,,
+Žilinský,Kysucké Nové Mesto,Horný Vadičov,1070,21,0.0196,1090,4,0.0037,,,,,,,,,
+Žilinský,Kysucké Nové Mesto,Kysucké Nové Mesto,8646,180,0.0208,8991,85,0.0095,,,,,,,,,
+Žilinský,Kysucké Nové Mesto,Kysucký Lieskovec,1375,18,0.0131,1418,8,0.0056,,,,,,,,,
+Žilinský,Kysucké Nové Mesto,Lodno,799,18,0.0225,726,7,0.0096,,,,,,,,,
+Žilinský,Kysucké Nové Mesto,Lopušné Pažite,583,3,0.0051,293,3,0.0102,80,3,0.0375,47,0,0,33,3,0.0909
+Žilinský,Kysucké Nové Mesto,Nesluša,1788,26,0.0145,1917,11,0.0057,,,,,,,,,
+Žilinský,Kysucké Nové Mesto,Ochodnica,542,10,0.0185,628,3,0.0048,,,,,,,,,
+Žilinský,Kysucké Nové Mesto,Povina,1107,26,0.0235,868,7,0.0081,,,,,,,,,
+Žilinský,Kysucké Nové Mesto,Radoľa,1306,13,0.01,1314,14,0.0107,422,10,0.0237,253,4,0.0158,169,6,0.0355
+Žilinský,Kysucké Nové Mesto,Rudina,1157,26,0.0225,1173,15,0.0128,283,3,0.0106,192,2,0.0104,91,1,0.011
+Žilinský,Kysucké Nové Mesto,Rudinská,1012,22,0.0217,799,13,0.0163,161,1,0.0062,124,1,0.0081,37,0,0
+Žilinský,Kysucké Nové Mesto,Snežnica,908,11,0.0121,823,7,0.0085,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Beňadiková,273,3,0.011,268,0,0,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Bobrovec,1376,10,0.0073,1388,11,0.0079,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Bobrovník,400,6,0.015,358,6,0.0168,43,1,0.0233,20,0,0,23,1,0.0435
+Žilinský,Liptovský Mikuláš,Demänovská Dolina,114,0,0,172,0,0,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Dúbrava,799,11,0.0138,844,13,0.0154,251,1,0.004,220,0,0,31,1,0.0323
+Žilinský,Liptovský Mikuláš,Gôtovany,458,4,0.0087,428,4,0.0093,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Huty,228,1,0.0044,224,4,0.0179,36,0,0,24,0,0,12,0,0
+Žilinský,Liptovský Mikuláš,Hybe,998,11,0.011,1077,2,0.0019,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Jakubovany,516,8,0.0155,424,5,0.0118,94,7,0.0745,59,4,0.0678,35,3,0.0857
+Žilinský,Liptovský Mikuláš,Jalovec,215,1,0.0047,215,4,0.0186,116,1,0.0086,89,1,0.0112,27,0,0
+Žilinský,Liptovský Mikuláš,Kráľova Lehota,348,2,0.0057,358,3,0.0084,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Kvačany,228,10,0.0439,250,1,0.004,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Lazisko,232,1,0.0043,251,1,0.004,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Liptovská Kokava,642,5,0.0078,675,9,0.0133,236,0,0,200,0,0,36,0,0
+Žilinský,Liptovský Mikuláš,Liptovská Porúbka,767,11,0.0143,799,8,0.01,191,6,0.0314,148,1,0.0068,43,5,0.1163
+Žilinský,Liptovský Mikuláš,Liptovská Sielnica,279,21,0.0753,268,0,0,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Liptovské Matiašovce,386,5,0.013,361,0,0,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Liptovský Hrádok,4022,38,0.0094,4338,17,0.0039,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Liptovský Ján,758,10,0.0132,780,3,0.0038,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Liptovský Mikuláš,17835,257,0.0144,18706,107,0.0057,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Liptovský Ondrej,736,15,0.0204,813,1,0.0012,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Liptovský Peter,809,5,0.0062,805,2,0.0025,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Liptovský Trnovec,575,3,0.0052,556,4,0.0072,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Ľubeľa,900,12,0.0133,903,2,0.0022,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Malé Borové,72,0,0,92,0,0,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Nižná Boca,551,1,0.0018,510,1,0.002,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Partizánska Ľupča,871,7,0.008,1057,7,0.0066,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Pavčina Lehota,476,11,0.0231,435,3,0.0069,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Pavlova Ves,443,6,0.0135,379,4,0.0106,54,3,0.0556,44,2,0.0455,10,1,0.1
+Žilinský,Liptovský Mikuláš,Podtureň,645,4,0.0062,668,3,0.0045,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Pribylina,954,15,0.0157,977,2,0.002,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Prosiek,357,16,0.0448,290,2,0.0069,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Smrečany,628,15,0.0239,576,0,0,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Svätý Kríž,807,40,0.0496,679,2,0.0029,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Uhorská Ves,487,6,0.0123,430,1,0.0023,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Vavrišovo,657,11,0.0167,614,1,0.0016,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Važec,1402,18,0.0128,1462,7,0.0048,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Veterná Poruba,227,2,0.0088,225,3,0.0133,67,4,0.0597,56,4,0.0714,11,0,0
+Žilinský,Liptovský Mikuláš,Vlachy,659,7,0.0106,638,3,0.0047,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Východná,1369,11,0.008,1375,13,0.0095,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Závažná Poruba,808,12,0.0149,832,3,0.0036,,,,,,,,,
+Žilinský,Liptovský Mikuláš,Žiar,299,8,0.0268,327,5,0.0153,179,1,0.0056,133,0,0,46,1,0.0217
+Žilinský,Martin,Belá-Dulice,886,16,0.0181,864,3,0.0035,,,,,,,,,
+Žilinský,Martin,Benice,466,4,0.0086,349,3,0.0086,,,,,,,,,
+Žilinský,Martin,Blatnica,620,20,0.0323,626,6,0.0096,,,,,,,,,
+Žilinský,Martin,Bystrička,823,10,0.0122,894,5,0.0056,,,,,,,,,
+Žilinský,Martin,Ďanová,489,3,0.0061,421,1,0.0024,,,,,,,,,
+Žilinský,Martin,Diaková,376,8,0.0213,368,1,0.0027,,,,,,,,,
+Žilinský,Martin,Dolný Kalník,372,5,0.0134,344,3,0.0087,,,,,,,,,
+Žilinský,Martin,Dražkovce,727,19,0.0261,647,3,0.0046,,,,,,,,,
+Žilinský,Martin,Folkušová,358,2,0.0056,262,0,0,,,,,,,,,
+Žilinský,Martin,Horný Kalník,296,4,0.0135,222,5,0.0225,81,0,0,33,0,0,48,0,0
+Žilinský,Martin,Karlová,346,10,0.0289,175,0,0,,,,,,,,,
+Žilinský,Martin,Kláštor pod Znievom,874,14,0.016,925,13,0.0141,491,16,0.0326,285,4,0.014,206,12,0.0583
+Žilinský,Martin,Košťany nad Turcom,1053,21,0.0199,937,6,0.0064,,,,,,,,,
+Žilinský,Martin,Krpeľany,623,4,0.0064,589,6,0.0102,158,0,0,121,0,0,37,0,0
+Žilinský,Martin,Laskár,353,2,0.0057,329,1,0.003,,,,,,,,,
+Žilinský,Martin,Ležiachov,195,1,0.0051,206,0,0,,,,,,,,,
+Žilinský,Martin,Lipovec,607,7,0.0115,584,5,0.0086,,,,,,,,,
+Žilinský,Martin,Martin,26557,319,0.012,28102,186,0.0066,,,,,,,,,
+Žilinský,Martin,Necpaly,498,3,0.006,577,3,0.0052,,,,,,,,,
+Žilinský,Martin,Nolčovo,374,9,0.0241,275,1,0.0036,,,,,,,,,
+Žilinský,Martin,Podhradie,504,11,0.0218,449,1,0.0022,,,,,,,,,
+Žilinský,Martin,Príbovce,655,7,0.0107,755,5,0.0066,,,,,,,,,
+Žilinský,Martin,Rakovo,447,7,0.0157,386,1,0.0026,,,,,,,,,
+Žilinský,Martin,Ratkovo,452,7,0.0155,297,2,0.0067,,,,,,,,,
+Žilinský,Martin,Sklabiňa,424,7,0.0165,437,5,0.0114,144,4,0.0278,122,0,0,22,4,0.1818
+Žilinský,Martin,Sklabinský Podzámok,326,6,0.0184,281,2,0.0071,,,,,,,,,
+Žilinský,Martin,Slovany,376,2,0.0053,360,2,0.0056,,,,,,,,,
+Žilinský,Martin,Sučany,2659,32,0.012,2842,12,0.0042,,,,,,,,,
+Žilinský,Martin,Šútovo,453,11,0.0243,422,1,0.0024,,,,,,,,,
+Žilinský,Martin,Trebostovo,483,2,0.0041,463,0,0,,,,,,,,,
+Žilinský,Martin,Trnovo,345,6,0.0174,303,0,0,,,,,,,,,
+Žilinský,Martin,Turany,2322,27,0.0116,2558,12,0.0047,,,,,,,,,
+Žilinský,Martin,Turčianska Štiavnička,688,20,0.0291,643,10,0.0156,231,3,0.013,191,1,0.0052,40,2,0.05
+Žilinský,Martin,Turčianské Jaseno,364,2,0.0055,370,2,0.0054,,,,,,,,,
+Žilinský,Martin,Turčianské Kľačany,868,9,0.0104,870,3,0.0034,,,,,,,,,
+Žilinský,Martin,Turčiansky Ďur,219,2,0.0091,210,1,0.0048,,,,,,,,,
+Žilinský,Martin,Turčiansky Peter,521,6,0.0115,505,0,0,,,,,,,,,
+Žilinský,Martin,Valča,884,20,0.0226,1003,7,0.007,,,,,,,,,
+Žilinský,Martin,Vrícko,454,4,0.0088,369,1,0.0027,,,,,,,,,
+Žilinský,Martin,Vrútky,4870,74,0.0152,5222,38,0.0073,,,,,,,,,
+Žilinský,Martin,Záborie,338,9,0.0266,205,3,0.0146,56,1,0.0179,23,1,0.0435,33,0,0
+Žilinský,Martin,Žabokreky,988,19,0.0192,867,22,0.0254,205,7,0.0341,124,0,0,81,7,0.0864
+Žilinský,Námestovo,Babín,864,25,0.0289,830,3,0.0036,,,,,,,,,
+Žilinský,Námestovo,Beňadovo,653,12,0.0184,641,10,0.0156,202,1,0.005,168,0,0,34,1,0.0294
+Žilinský,Námestovo,Bobrov,1152,18,0.0156,1273,8,0.0063,,,,,,,,,
+Žilinský,Námestovo,Breza,840,6,0.0071,1022,3,0.0029,,,,,,,,,
+Žilinský,Námestovo,Hruštín,1798,39,0.0217,1810,5,0.0028,,,,,,,,,
+Žilinský,Námestovo,Klin,1239,19,0.0153,1386,7,0.0051,,,,,,,,,
+Žilinský,Námestovo,Krušetnica,665,7,0.0105,638,4,0.0063,,,,,,,,,
+Žilinský,Námestovo,Lokca,1246,35,0.0281,1330,6,0.0045,,,,,,,,,
+Žilinský,Námestovo,Lomná,620,7,0.0113,629,5,0.0079,,,,,,,,,
+Žilinský,Námestovo,Mútne,1723,43,0.025,1733,12,0.0069,,,,,,,,,
+Žilinský,Námestovo,Námestovo,5120,87,0.017,5192,19,0.0037,,,,,,,,,
+Žilinský,Námestovo,Novoť,1878,32,0.017,1997,22,0.011,602,5,0.0083,553,4,0.0072,49,1,0.0204
+Žilinský,Námestovo,Oravská Jasenica,1211,17,0.014,1204,4,0.0033,,,,,,,,,
+Žilinský,Námestovo,Oravská Lesná,1892,34,0.018,2128,8,0.0038,,,,,,,,,
+Žilinský,Námestovo,Oravská Polhora,2355,46,0.0195,2327,15,0.0064,,,,,,,,,
+Žilinský,Námestovo,Oravské Veselé,1806,22,0.0122,1796,8,0.0045,,,,,,,,,
+Žilinský,Námestovo,Rabča,2736,69,0.0252,2825,16,0.0057,,,,,,,,,
+Žilinský,Námestovo,Rabčice,1166,21,0.018,1143,0,0,,,,,,,,,
+Žilinský,Námestovo,Sihelné,1228,18,0.0147,1182,7,0.0059,,,,,,,,,
+Žilinský,Námestovo,Ťapešovo,719,11,0.0153,600,4,0.0067,,,,,,,,,
+Žilinský,Námestovo,Vasiľov,626,3,0.0048,598,3,0.005,,,,,,,,,
+Žilinský,Námestovo,Vavrečka,906,5,0.0055,934,2,0.0021,,,,,,,,,
+Žilinský,Námestovo,Zakamenné,3123,75,0.024,3256,28,0.0086,,,,,,,,,
+Žilinský,Námestovo,Zubrohlava,1095,19,0.0174,1185,8,0.0068,,,,,,,,,
+Žilinský,Ružomberok,Bešeňová,499,7,0.014,513,1,0.0019,,,,,,,,,
+Žilinský,Ružomberok,Hubová,671,6,0.0089,659,7,0.0106,287,14,0.0488,207,7,0.0338,80,7,0.0875
+Žilinský,Ružomberok,Ivachnová,298,3,0.0101,316,1,0.0032,,,,,,,,,
+Žilinský,Ružomberok,Kalameny,364,4,0.011,332,6,0.0181,124,4,0.0323,98,0,0,26,4,0.1538
+Žilinský,Ružomberok,Komjatná,850,14,0.0165,828,5,0.006,,,,,,,,,
+Žilinský,Ružomberok,Likavka,1651,43,0.026,1613,7,0.0043,,,,,,,,,
+Žilinský,Ružomberok,Liptovská Lúžna,1524,23,0.0151,1577,4,0.0025,,,,,,,,,
+Žilinský,Ružomberok,Liptovská Osada,1059,21,0.0198,1041,4,0.0038,,,,,,,,,
+Žilinský,Ružomberok,Liptovská Štiavnica,761,12,0.0158,762,9,0.0118,250,5,0.02,195,5,0.0256,55,0,0
+Žilinský,Ružomberok,Liptovská Teplá,582,9,0.0155,618,5,0.0081,,,,,,,,,
+Žilinský,Ružomberok,Liptovské Revúce,884,11,0.0124,918,4,0.0044,,,,,,,,,
+Žilinský,Ružomberok,Liptovské Sliače,2000,53,0.0265,1954,13,0.0067,,,,,,,,,
+Žilinský,Ružomberok,Liptovský Michal,430,4,0.0093,351,1,0.0028,,,,,,,,,
+Žilinský,Ružomberok,Lisková,1397,38,0.0272,1418,12,0.0085,,,,,,,,,
+Žilinský,Ružomberok,Ľubochňa,840,13,0.0155,811,7,0.0086,,,,,,,,,
+Žilinský,Ružomberok,Lúčky,935,17,0.0182,967,3,0.0031,,,,,,,,,
+Žilinský,Ružomberok,Ludrová,637,15,0.0235,614,3,0.0049,,,,,,,,,
+Žilinský,Ružomberok,Martinček,201,1,0.005,203,0,0,,,,,,,,,
+Žilinský,Ružomberok,Potok,81,1,0.0123,91,2,0.022,76,1,0.0132,41,1,0.0244,35,0,0
+Žilinský,Ružomberok,Ružomberok,14982,272,0.0182,15152,107,0.0071,,,,,,,,,
+Žilinský,Ružomberok,Stankovany,702,25,0.0356,690,4,0.0058,,,,,,,,,
+Žilinský,Ružomberok,Štiavnička,638,15,0.0235,548,0,0,,,,,,,,,
+Žilinský,Ružomberok,Švošov,545,13,0.0239,518,2,0.0039,,,,,,,,,
+Žilinský,Ružomberok,Valaská Dubová,517,6,0.0116,562,29,0.0516,265,4,0.0151,214,0,0,51,4,0.0784
+Žilinský,Turčianske Teplice,Abramová,268,3,0.0112,383,0,0,,,,,,,,,
+Žilinský,Turčianske Teplice,Blažovce,215,5,0.0233,185,0,0,,,,,,,,,
+Žilinský,Turčianske Teplice,Bodorová,243,2,0.0082,240,0,0,,,,,,,,,
+Žilinský,Turčianske Teplice,Borcová,165,2,0.0121,174,0,0,,,,,,,,,
+Žilinský,Turčianske Teplice,Brieštie,161,0,0,169,0,0,,,,,,,,,
+Žilinský,Turčianske Teplice,Budiš,177,3,0.0169,186,0,0,,,,,,,,,
+Žilinský,Turčianske Teplice,Čremošné,309,1,0.0032,294,1,0.0034,,,,,,,,,
+Žilinský,Turčianske Teplice,Dubové,458,10,0.0218,470,4,0.0085,,,,,,,,,
+Žilinský,Turčianske Teplice,Háj,421,11,0.0261,388,1,0.0026,,,,,,,,,
+Žilinský,Turčianske Teplice,Horná Štubňa,813,2,0.0025,869,3,0.0035,,,,,,,,,
+Žilinský,Turčianske Teplice,Ivančiná,151,2,0.0132,158,2,0.0127,38,0,0,14,0,0,24,0,0
+Žilinský,Turčianske Teplice,Jasenovo,236,2,0.0085,388,0,0,,,,,,,,,
+Žilinský,Turčianske Teplice,Jazernica,348,3,0.0086,347,4,0.0115,85,0,0,81,0,0,4,0,0
+Žilinský,Turčianske Teplice,Kaľamenová,140,1,0.0071,129,0,0,,,,,,,,,
+Žilinský,Turčianske Teplice,Liešno,93,4,0.043,58,0,0,,,,,,,,,
+Žilinský,Turčianske Teplice,Malý Čepčín,433,2,0.0046,412,5,0.0121,106,0,0,79,0,0,27,0,0
+Žilinský,Turčianske Teplice,Moškovec,223,7,0.0314,175,2,0.0114,42,1,0.0238,18,0,0,24,1,0.0417
+Žilinský,Turčianske Teplice,Mošovce,902,3,0.0033,892,2,0.0022,,,,,,,,,
+Žilinský,Turčianske Teplice,Rakša,337,8,0.0237,313,0,0,,,,,,,,,
+Žilinský,Turčianske Teplice,Rudno,202,5,0.0248,195,1,0.0051,,,,,,,,,
+Žilinský,Turčianske Teplice,Sklené,452,1,0.0022,509,7,0.0138,177,1,0.0056,165,1,0.0061,12,0,0
+Žilinský,Turčianske Teplice,Slovenské Pravno,531,1,0.0019,542,4,0.0074,,,,,,,,,
+Žilinský,Turčianske Teplice,Turček,443,6,0.0135,906,0,0,,,,,,,,,
+Žilinský,Turčianske Teplice,Turčianske Teplice,3173,28,0.0088,3622,18,0.005,,,,,,,,,
+Žilinský,Turčianske Teplice,Veľký Čepčín,393,0,0,206,0,0,,,,,,,,,
+Žilinský,Tvrdošín,Brezovica,856,22,0.0257,837,9,0.0108,227,1,0.0044,208,0,0,19,1,0.0526
+Žilinský,Tvrdošín,Čimhová,529,18,0.034,466,2,0.0043,,,,,,,,,
+Žilinský,Tvrdošín,Habovka,738,13,0.0176,819,4,0.0049,,,,,,,,,
+Žilinský,Tvrdošín,Hladovka,607,13,0.0214,595,3,0.005,,,,,,,,,
+Žilinský,Tvrdošín,Liesek,1595,75,0.047,1567,16,0.0102,423,8,0.0189,377,5,0.0133,46,3,0.0652
+Žilinský,Tvrdošín,Nižná,2244,26,0.0116,2269,9,0.004,,,,,,,,,
+Žilinský,Tvrdošín,Oravský Biely Potok,510,7,0.0137,539,2,0.0037,,,,,,,,,
+Žilinský,Tvrdošín,Podbiel,889,6,0.0067,828,6,0.0072,,,,,,,,,
+Žilinský,Tvrdošín,Suchá Hora,829,23,0.0277,833,5,0.006,,,,,,,,,
+Žilinský,Tvrdošín,Štefanov nad Oravou,492,18,0.0366,449,7,0.0156,187,4,0.0214,137,1,0.0073,50,3,0.06
+Žilinský,Tvrdošín,Trstená,3718,89,0.0239,3833,32,0.0083,,,,,,,,,
+Žilinský,Tvrdošín,Tvrdošín,4699,77,0.0164,4927,46,0.0093,,,,,,,,,
+Žilinský,Tvrdošín,Vitanová,755,22,0.0291,779,9,0.0116,167,2,0.012,142,0,0,25,2,0.08
+Žilinský,Tvrdošín,Zábiedovo,568,19,0.0335,526,10,0.019,238,8,0.0336,211,5,0.0237,27,3,0.1111
+Žilinský,Tvrdošín,Zuberec,1171,20,0.0171,1235,4,0.0032,,,,,,,,,
+Žilinský,Žilina,Belá,2351,71,0.0302,2273,13,0.0057,,,,,,,,,
+Žilinský,Žilina,Bitarová,820,10,0.0122,674,1,0.0015,,,,,,,,,
+Žilinský,Žilina,Brezany,500,3,0.006,473,0,0,,,,,,,,,
+Žilinský,Žilina,Divina,1641,31,0.0189,1614,0,0,,,,,,,,,
+Žilinský,Žilina,Divinka,836,8,0.0096,796,3,0.0038,,,,,,,,,
+Žilinský,Žilina,Dlhé Pole,1620,27,0.0167,1470,6,0.0041,,,,,,,,,
+Žilinský,Žilina,Dolná Tižina,817,15,0.0184,866,2,0.0023,,,,,,,,,
+Žilinský,Žilina,Dolný Hričov,1116,9,0.0081,996,2,0.002,,,,,,,,,
+Žilinský,Žilina,Ďurčiná,821,5,0.0061,772,4,0.0052,,,,,,,,,
+Žilinský,Žilina,Fačkov,670,4,0.006,684,5,0.0073,,,,,,,,,
+Žilinský,Žilina,Gbeľany,998,14,0.014,876,10,0.0114,507,22,0.0434,242,3,0.0124,265,19,0.0717
+Žilinský,Žilina,Horný Hričov,626,16,0.0256,614,4,0.0065,,,,,,,,,
+Žilinský,Žilina,Hôrky,838,6,0.0072,716,2,0.0028,,,,,,,,,
+Žilinský,Žilina,Hričovské Podhradie,552,15,0.0272,482,2,0.0041,,,,,,,,,
+Žilinský,Žilina,Jasenové,615,9,0.0146,494,1,0.002,,,,,,,,,
+Žilinský,Žilina,Kamenná Poruba,1191,15,0.0126,1165,3,0.0026,,,,,,,,,
+Žilinský,Žilina,Kľače,221,6,0.0271,232,1,0.0043,,,,,,,,,
+Žilinský,Žilina,Konská,966,22,0.0228,930,5,0.0054,,,,,,,,,
+Žilinský,Žilina,Kotrčiná Lúčka,1130,24,0.0212,,,,,,,,,,,,
+Žilinský,Žilina,Krasňany,1092,16,0.0147,1068,6,0.0056,,,,,,,,,
+Žilinský,Žilina,Kunerad,816,7,0.0086,804,3,0.0037,,,,,,,,,
+Žilinský,Žilina,Lietava,1149,10,0.0087,1026,1,0.001,,,,,,,,,
+Žilinský,Žilina,Lietavská Lúčka,1166,5,0.0043,1284,8,0.0062,,,,,,,,,
+Žilinský,Žilina,Lietavská Svinná - Babkov,1324,15,0.0113,1242,5,0.004,,,,,,,,,
+Žilinský,Žilina,Lutiše,680,12,0.0176,685,5,0.0073,,,,,,,,,
+Žilinský,Žilina,Lysica,768,9,0.0117,740,0,0,,,,,,,,,
+Žilinský,Žilina,Malá Čierna,398,1,0.0025,325,0,0,,,,,,,,,
+Žilinský,Žilina,Mojš,1268,20,0.0158,1215,4,0.0033,,,,,,,,,
+Žilinský,Žilina,Nededza,0,0,0,1058,5,0.0047,,,,,,,,,
+Žilinský,Žilina,Nezbudská Lúčka,281,8,0.0285,265,2,0.0075,,,,,,,,,
+Žilinský,Žilina,Ovčiarsko,391,3,0.0077,406,3,0.0074,,,,,,,,,
+Žilinský,Žilina,Paština Závada,216,1,0.0046,202,2,0.0099,,,,,,,,,
+Žilinský,Žilina,Podhorie,735,26,0.0354,625,4,0.0064,,,,,,,,,
+Žilinský,Žilina,Porúbka,528,3,0.0057,470,3,0.0064,,,,,,,,,
+Žilinský,Žilina,Rajec,3484,31,0.0089,3703,28,0.0076,,,,,,,,,
+Žilinský,Žilina,Rajecká Lesná,827,7,0.0085,863,10,0.0116,339,13,0.0383,273,6,0.022,66,7,0.1061
+Žilinský,Žilina,Rajecké Teplice,2138,37,0.0173,2117,17,0.008,,,,,,,,,
+Žilinský,Žilina,Rosina,1667,18,0.0108,1780,6,0.0034,,,,,,,,,
+Žilinský,Žilina,Stráňavy,1334,26,0.0195,1289,5,0.0039,,,,,,,,,
+Žilinský,Žilina,Stránske,562,2,0.0036,536,4,0.0075,,,,,,,,,
+Žilinský,Žilina,Stráža,591,6,0.0102,514,2,0.0039,,,,,,,,,
+Žilinský,Žilina,Strečno,1883,15,0.008,1849,8,0.0043,,,,,,,,,
+Žilinský,Žilina,Svederník,1004,11,0.011,1045,3,0.0029,,,,,,,,,
+Žilinský,Žilina,Teplička nad Váhom,2748,50,0.0182,2667,26,0.0097,,,,,,,,,
+Žilinský,Žilina,Terchová,2749,24,0.0087,3031,7,0.0023,,,,,,,,,
+Žilinský,Žilina,Turie,2066,27,0.0131,1869,14,0.0075,,,,,,,,,
+Žilinský,Žilina,Varín,2288,38,0.0166,2415,11,0.0046,,,,,,,,,
+Žilinský,Žilina,Veľká Čierna,212,0,0,216,4,0.0185,87,3,0.0345,71,3,0.0423,16,0,0
+Žilinský,Žilina,Višňové,1881,15,0.008,1982,8,0.004,,,,,,,,,
+Žilinský,Žilina,Zbyňov,914,14,0.0153,793,8,0.0101,239,4,0.0167,132,1,0.0076,107,3,0.028
+Žilinský,Žilina,Žilina,48468,521,0.0107,49491,236,0.0048,,,,,,,,,


### PR DESCRIPTION
Converted from PDF documents published on the website of Ministry of Defense
Sources:
- https://mosr.sk/48425-sk/ustredny-krizovy-stab-schvalil-stvrte-kolo-testovania-bude-dobrovolne-a-tykat-sa-ma-458-miest-a-obci/
- https://mosr.sk/48501-sk/rezort-obrany-spristupnil-podrobne-vysledky-miest-a-obci-z-uplynuleho-testovania-k-dispozicii-je-aj-porovnanie-ich-vysledkov-s-predchadzajucimi-kolami/

E2 phase: 2020-10-31 - 2020-11-01
E3 phase: 2020-11-07 - 2020-11-08
E4 phase: 2020-11-21 - 2020-11-22

The E4 phase was voluntary (no curfew for people who did not participate in antigen testing) in municipalities where a positive test rate of over 1 percent was found in previous testing. Some locations were included at their own request or due to incorrect statistical data processing by the military. The phase data also include additional columns dividing test and positive individuals into residents (`E4_residents`) and others (`E4_transients`)

Additionally, some errors have been manually fixed in this dataset:
- incorrectly mentioned regions and districts
- resolved duplications
- minor typos